### PR TITLE
Adds sanity-validation check to ensure the delete action is supported…

### DIFF
--- a/scripts/zen_dojotools_calendar.yaml
+++ b/scripts/zen_dojotools_calendar.yaml
@@ -481,7 +481,59 @@ sequence:
 
 
         sequence:
+          - variables:
+              ###########################################################################
+              # Mapping of domain → supported feature names.
+              # Converts numeric bitmasks to human-readable feature sets.
+              ###########################################################################
+              SUPPORTED_FEATURES:
+                calendar:
+                  name: CalendarEntityFeature
+                  enum:
+                    CREATE_EVENT: 1
+                    DELETE_EVENT: 2
+                    UPDATE_EVENT: 4
+
+              calendar_features: >
+                {{- state_attr(calendar_entity, 'supported_features') | int(0) -}}
+              supports_delete: >
+                {%- set supp_val = SUPPORTED_FEATURES.calendar.enum.DELETE_EVENT -%}
+                {%- set test = calendar_features | int | bitwise_and(supp_val) -%}
+                {{- supp_val==test -}}
+
           - choose:
+              - conditions:
+                  - alias: "Error: Calendar does not support delete event"
+                    condition: template
+                    value_template: >
+                      {{- not supports_delete -}}
+                sequence:
+                  - variables:
+                      calendar_entity_list: >-
+                        {%- set ce = calendar_entity | default(none) -%} 
+                        {%- if ce is iterable and not ce is string -%}
+                          {{ ce | list }}
+                        {%- elif ce is string and ce | length > 0 -%}
+                          [{{ ce | tojson }}]
+                        {%- else -%}
+                          []
+                        {%- endif -%}
+                  - action: script.dojotools_zen_inspect
+                    data:
+                      entity_id: "{{calendar_entity_list}}"
+                    response_variable: inspect_response
+                  - variables:
+                      final_response: |-
+                        {{
+                          {
+                            "status": "error",
+                            "message": "Delete requires a calendar entity that supports delete",
+                            "inspect": inspect_response | default({})
+                          }
+                        }}
+                  - stop: Pass response variables back to LLM
+                    response_variable: final_response
+                  - set_conversation_response: "{{final_response}}"
               - conditions:
                   - alias: "Error: Missing Required Field"
                     condition: template


### PR DESCRIPTION
… by the target calendar (integration) for 'Zen Dojotools Calendar' prior to deletion.

NOT Tested in this context: - just in my own version of this calendar functionality.

Proof of concept - developer tools...

```jinga
{%- set calendar_entity = 'calendar.family_planner' -%}
{%- set calendar_features = state_attr(calendar_entity, 'supported_features') | int(0) -%}
{%- set SUPPORTED_FEATURES = {
  'calendar': {
    'name': 'CalendarEntityFeature',
    'enum': {
      'CREATE_EVENT': 1,
      'DELETE_EVENT': 2,
      'UPDATE_EVENT': 4,
      }
    }
  } -%}
{%- set supp_val = SUPPORTED_FEATURES.calendar.enum.DELETE_EVENT -%}
{%- set test = calendar_features | int | bitwise_and(supp_val) %}
{%- set rv = supp_val==test %}
calendar_features {{ calendar_features }}
supp_val {{ supp_val }}
test {{ test }}
rv {{ rv }}