### PR TITLE
2025-12-17-Simplify-zenos_label_health

### DIFF
--- a/packages/zenos_ai/zenos_label_health.yaml
+++ b/packages/zenos_ai/zenos_label_health.yaml
@@ -9,8 +9,10 @@
 
 template:
   - sensor:
+      # sensor.zen_label_health
       - name: Zen Label Health
         unique_id: zen_label_health
+        default_entity_id: sensor.zen_label_health
         device_class: enum
         variables:
 

--- a/packages/zenos_ai/zenos_label_health.yaml
+++ b/packages/zenos_ai/zenos_label_health.yaml
@@ -12,152 +12,134 @@ template:
       - name: Zen Label Health
         unique_id: zen_label_health
         device_class: enum
-        availability: "true"
+        variables:
+
+          required_labels:
+          - 'Zen Cabinet'
+          - 'Zen System Cabinet'
+          - 'Zen Dojo Cabinet'
+          - 'Zen Kata Cabinet'
+          - 'Zen Default Household'
+          - 'Zen Default Family'
+          - 'Zen User Cabinet'
+          - 'Zen Default User Cabinet'
+          - 'Zen AI User Cabinet'
+          - 'Zen Default AI User Cabinet'
+          - 'Zen Squirrel'
+          - 'Zen Fusion'
+          - 'Zen History Cabinet'
+          - 'Zen Index Cabinet'
+          - 'Zen Health'
+          - 'Zen Household'
+          - 'Zen Family'
+          - 'Zen User'
+          - 'Zen AI User'
+
+          required_ids: >
+            {{-  required_labels | map('slugify') | list -}}
+
+          label_index: >
+            {{- labels() -}}
+
+          existing_label_ids: >
+            {{- required_ids | select( 'in',  label_index) | list -}}
+
+          # ----------------------------- #
+          # 1. Missing label entirely
+          # ----------------------------- #
+          missing_label_ids: >
+            {{- required_ids | reject( 'in',  existing_label_ids) | list -}}
+
+          # ALL entities that are using a required label
+          required_label_entities: >-
+            {{- required_ids | map('label_entities') | list | sum(start=[]) -}}
+
+          # [The Labels of] ALL entities that are using a required label
+          required_label_entities_labels: >-
+            {{- required_label_entities | map('labels') | sum(start=[]) | unique | list -}}
+
+          # The required labels that have been assigned to an entity
+          assigned_label_ids: >-
+            {{- required_ids | select( 'in', required_label_entities_labels )  -}}
+
+          # ----------------------------- #
+          # 2. Unassigned: exists, 0 entities #
+          # The required labels that have been assigned to an entity
+          # ----------------------------- #
+          unassigned_label_ids: >-
+            {{- required_ids | reject( 'in', assigned_label_ids ) | list  -}}
+
+          # ALL entities that are using a required label but which have no state ('unknown'/'unavailable')
+          required_label_entities_bad: >-
+            {{- required_label_entities | reject('has_state') | list -}}
+
+          # [The Labels of] ALL entities that are using a required label but which have no state ('unknown'/'unavailable')
+          required_label_entities_bad_labels: >-
+            {{- required_label_entities_bad | map('labels') | sum(start=[]) | unique | list -}}
+
+          healthy_label_ids: >-
+            {{- required_ids 
+              | reject( 'in', missing_label_ids ) 
+              | reject( 'in', unassigned_label_ids ) 
+              | reject( 'in', required_label_entities_bad_labels ) 
+              | list 
+            -}}
+
+          # ---------------------------------------- #
+          # 3. Unhealthy: one or more ents unavailable
+          # ---------------------------------------- #
+          unhealthy_label_ids: >-
+            {{- required_ids | reject( 'in', healthy_label_ids ) | list -}}
+
+        #availability: "true"
 
         #######################################################################
         # STATE
         #######################################################################
         state: >-
-          {% set required = [
-            'Zen Cabinet',
-            'Zen System Cabinet',
-            'Zen Dojo Cabinet',
-            'Zen Kata Cabinet',
-            'Zen Default Household',
-            'Zen Default Family',
-            'Zen User Cabinet',
-            'Zen Default User Cabinet',
-            'Zen AI User Cabinet',
-            'Zen Default AI User Cabinet',
-            'Zen Squirrel',
-            'Zen Fusion',
-            'Zen History Cabinet',
-            'Zen Index Cabinet',
-            'Zen Health',
-            'Zen Household',
-            'Zen Family',
-            'Zen User',
-            'Zen AI User'
-          ] %}
-
-          {% set required_ids = required | map('slugify') | list %}
-          {% set label_index = labels() %}
-
-          {% set ns = namespace(
-              missing = [],
-              unassigned = [],
-              unhealthy = []
-          ) %}
-
-          {% for lid in required_ids %}
-
-            {# ----------------------------- #}
-            {# 1. Missing label entirely     #}
-            {# ----------------------------- #}
-            {% if lid not in label_index %}
-              {% set ns.missing = ns.missing + [lid] %}
-            {% else %}
-              {% set ents = label_entities(lid) or [] %}
-
-              {# -------------------------------- #}
-              {# 2. Unassigned: exists, 0 entities #}
-              {# -------------------------------- #}
-              {% if ents | count == 0 %}
-                {% set ns.unassigned = ns.unassigned + [lid] %}
-              {% else %}
-
-                {# ---------------------------------------- #}
-                {# 3. Unhealthy: one or more ents unavailable #}
-                {# ---------------------------------------- #}
-                {% set bad = ents
-                    | selectattr('state','in',['unavailable', 'unknown'])
-                    | list %}
-                {% if bad | count > 0 %}
-                  {% set ns.unhealthy = ns.unhealthy + [lid] %}
-                {% endif %}
-
-              {% endif %}
-            {% endif %}
-
-          {% endfor %}
-
           {# ----------------------------- #}
           {# PRIORITY: missing > unhealthy > unassigned > ok #}
           {# ----------------------------- #}
-
-          {% if ns.missing | count > 0 %}
-            critical
-          {% elif ns.unhealthy | count > 0 %}
-            error
-          {% elif ns.unassigned | count > 0 %}
-            warn
-          {% else %}
-            ok
-          {% endif %}
+          {%- set rv = 'ok' -%}
+          {%- if missing_label_ids | count > 0 -%}
+            {%- set rv = 'critical' -%}
+          {%- elif unhealthy_label_ids | count > 0 -%}
+            {%- set rv = 'error' -%}
+          {%- elif unassigned_label_ids | count > 0 -%}
+            {%- set rv = 'warn' -%}
+          {%- endif -%}
+          {{- rv -}}
 
         #######################################################################
         # ATTRIBUTES
         #######################################################################
         attributes:
 
-          required_labels: >-
-            Zen Cabinet, Zen System Cabinet, Zen Dojo Cabinet, Zen Kata Cabinet,
-            Zen Default Household, Zen Default Family, Zen User Cabinet,
-            Zen Default User Cabinet, Zen AI User Cabinet,
-            Zen Default AI User Cabinet, Zen Squirrel, Zen Fusion,
-            Zen History Cabinet, Zen Index Cabinet, Zen Health,
-            Zen Household, Zen Family, Zen User, Zen AI User
+          required_labels: >
+            {{- required_labels | join(', ') -}}
 
-          existing_label_ids: >-
-            {% set required = [
-              'Zen Cabinet','Zen System Cabinet','Zen Dojo Cabinet','Zen Kata Cabinet',
-              'Zen Default Household','Zen Default Family','Zen User Cabinet',
-              'Zen Default User Cabinet','Zen AI User Cabinet','Zen Default AI User Cabinet',
-              'Zen Squirrel','Zen Fusion','Zen History Cabinet','Zen Index Cabinet',
-              'Zen Health','Zen Household','Zen Family','Zen User','Zen AI User'
-            ] %}
-            {% set required_ids = required | map('slugify') | list %}
-            {% set label_index = labels() %}
-            {% set ns = namespace(ex=[]) %}
-            {% for lid in required_ids %}
-              {% if lid in label_index %}
-                {% set ns.ex = ns.ex + [lid] %}
-              {% endif %}
-            {% endfor %}
-            {{ ns.ex | join(', ') if ns.ex else 'none' }}
+          existing_label_ids: >
+            {{- existing_label_ids | join(', ') if existing_label_ids else 'none' -}}
 
+          # --------------------------------------------------------
+          # 1. Missing label entirely
+          # --------------------------------------------------------
           missing_label_ids: >-
-            {% set required = [
-              'Zen Cabinet','Zen System Cabinet','Zen Dojo Cabinet','Zen Kata Cabinet',
-              'Zen Default Household','Zen Default Family','Zen User Cabinet',
-              'Zen Default User Cabinet','Zen AI User Cabinet','Zen Default AI User Cabinet',
-              'Zen Squirrel','Zen Fusion','Zen History Cabinet','Zen Index Cabinet',
-              'Zen Health','Zen Household','Zen Family','Zen User','Zen AI User'
-            ] %}
-            {% set required_ids = required | map('slugify') | list %}
-            {% set label_index = labels() %}
-            {% set ns = namespace(miss=[]) %}
-            {% for lid in required_ids %}
-              {% if lid not in label_index %}
-                {% set ns.miss = ns.miss + [lid] %}
-              {% endif %}
-            {% endfor %}
-            {{ ns.miss | join(', ') if ns.miss else 'none' }}
+            {{- missing_label_ids | join(', ') if missing_label_ids else 'none' -}}
 
           #######################################################################
           # BROKEN / UNASSIGNED / UNHEALTHY LABEL IDS
           #######################################################################
 
-          unassigned_label_ids: >-
-            {% set required = [
-              'Zen Cabinet','Zen System Cabinet','Zen Dojo Cabinet','Zen Kata Cabinet',
-              'Zen Default Household','Zen Default Family','Zen User Cabinet',
-              'Zen Default User Cabinet','Zen AI User Cabinet','Zen Default AI User Cabinet',
-              'Zen Squirrel','Zen Fusion','Zen History Cabinet','Zen Index Cabinet',
-              'Zen Health','Zen Household','Zen Family','Zen User','Zen AI User'
-            ] %}
-            {% set required_ids = required | map('slugify') | list %}
-            {% set label_index = labels() %}
+          # --------------------------------------------------------
+          # # 2. Unassigned: exists, 0 entities #
+          # Labels that...
+          # a) Do not exist in the user's configuration (therefore unassigned - these were not included in v1.1.0)
+          # b) Exist, but have not been assigned to an entity
+          # --------------------------------------------------------
+          # @todo: Remove: unassigned_label_ids_deprecated - Retained for output comparison
+          # --------------------------------------------------------
+          unassigned_label_ids_deprecated: >-
             {% set ns = namespace(unassigned=[]) %}
 
             {% for lid in required_ids %}
@@ -171,16 +153,19 @@ template:
 
             {{ ns.unassigned | join(', ') if ns.unassigned else 'none' }}
 
-          unhealthy_label_ids: >-
-            {% set required = [
-              'Zen Cabinet','Zen System Cabinet','Zen Dojo Cabinet','Zen Kata Cabinet',
-              'Zen Default Household','Zen Default Family','Zen User Cabinet',
-              'Zen Default User Cabinet','Zen AI User Cabinet','Zen Default AI User Cabinet',
-              'Zen Squirrel','Zen Fusion','Zen History Cabinet','Zen Index Cabinet',
-              'Zen Health','Zen Household','Zen Family','Zen User','Zen AI User'
-            ] %}
-            {% set required_ids = required | map('slugify') | list %}
-            {% set label_index = labels() %}
+          unassigned_label_ids: >-
+            {{ unassigned_label_ids | join(', ') if unassigned_label_ids else 'none' }}
+
+          # --------------------------------------------------------
+          # 3. Unhealthy: one or more ents unavailable
+          # Labels that...
+          # a) Do not exist in the user's configuration (therefore unassigned - these were not included in v1.1.0)
+          # b) Exist, but have not been assigned to an entity (therefore unassigned - these were not included in v1.1.0)
+          # c) Exist, AND have been assigned to an entity that has no value
+          # --------------------------------------------------------
+          # @todo: Remove: unhealthy_label_ids_deprecated - Retained for output comparison
+          # --------------------------------------------------------
+          unhealthy_label_ids_deprecated: >-
             {% set ns = namespace(unhealthy=[]) %}
 
             {% for lid in required_ids %}
@@ -197,16 +182,13 @@ template:
 
             {{ ns.unhealthy | join(', ') if ns.unhealthy else 'none' }}
 
-          healthy_label_ids: >-
-            {% set required = [
-              'Zen Cabinet','Zen System Cabinet','Zen Dojo Cabinet','Zen Kata Cabinet',
-              'Zen Default Household','Zen Default Family','Zen User Cabinet',
-              'Zen Default User Cabinet','Zen AI User Cabinet','Zen Default AI User Cabinet',
-              'Zen Squirrel','Zen Fusion','Zen History Cabinet','Zen Index Cabinet',
-              'Zen Health','Zen Household','Zen Family','Zen User','Zen AI User'
-            ] %}
-            {% set required_ids = required | map('slugify') | list %}
-            {% set label_index = labels() %}
+          unhealthy_label_ids: >-
+            {{ unhealthy_label_ids | join(', ') if unhealthy_label_ids else 'none' }}
+
+          # --------------------------------------------------------
+          # @todo: Remove: healthy_label_ids_deprecated - Retained for output comparison
+          # --------------------------------------------------------
+          healthy_label_ids_deprecated: >-
             {% set ns = namespace(ok=[]) %}
             {% for lid in required_ids %}
               {% if lid in label_index %}
@@ -220,5 +202,8 @@ template:
               {% endif %}
             {% endfor %}
             {{ ns.ok | join(', ') if ns.ok else 'none' }}
+
+          healthy_label_ids: >-
+            {{ healthy_label_ids | join(', ') if healthy_label_ids else 'none' }}
 
           timestamp: "{{ now().isoformat() }}"


### PR DESCRIPTION
zenos_label_health.yaml

Refactoring of duplicated jinja in zenos_label_health with redefinition of required_labels

Simplifies maintenance of required labels by moving them (and a slew of other related calculations with dependencies of previous calculations) to a variables section in the template sensor.

Removes for loops and namespaces by solely folcusing on faster select|reject statements.

Remove template availability (obsolete).