### PR TITLE
2025-12-20-Fix-Invalid-Index-Result

### DIFF
--- a/scripts/zen_dojotools_index.yaml
+++ b/scripts/zen_dojotools_index.yaml
@@ -281,8 +281,8 @@ sequence:
         sequence:
           - variables:
               expanded_entities: "{{ entities_base }}"
-              matched_drawers: "[]"
-              matched_drawer_labels: "[]"
+              matched_drawers: []
+              matched_drawer_labels: []
         alias: Expand = false
     alias: "Prepare [ Expand ] Result Set "
   - variables:


### PR DESCRIPTION
script.zen_dojotools_index

FIX: The output from the Zen Index returns a malformed list for the following nodes:
- drawer_adjacent_labels
- drawers

```YAML
result:
  adjacent_labels: []
  drawer_adjacent_labels:
    - "["
    - "]"
  drawers:
    - "["
    - "]"
  expanded: []
  ```

  This fixes that issue and ensures that the data is correctly formatted as a list