### PR TITLE
fix: harden .gitignore for cloners — known_devices.yaml + !*.jinja

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,11 +4,15 @@ home-assistant_v2.db*
 *.db-shm
 *.db-wal
 secrets.yaml
+known_devices.yaml
 custom_components/__pycache__/
 deps/
 storage/
 *.storage
 *.cloud
+
+# Explicitly track Jinja templates (in case of blanket ignores downstream)
+!*.jinja
 
 # General Python junk
 __pycache__/


### PR DESCRIPTION
## Summary

Surgical hardening of `.gitignore` for anyone cloning the repo into their own HA config directory:

- **`known_devices.yaml`** — contains MAC addresses and device names, same risk profile as `secrets.yaml` for careless `git add .` users. Added alongside it. (`secrets.yaml` was already correctly ignored.)
- **`!*.jinja`** — explicitly whitelists Jinja templates so they survive any blanket ignore rules a user might have in a parent `.gitignore`. Not blocking anything currently but makes intent clear.

Deliberately does **not** change the overall structure of the gitignore or introduce a blanket `*` model — that's tuned to a specific local setup and would be aggressive for upstream users.

## Test plan
- [ ] Verify `secrets.yaml` still ignored (was already, unchanged)
- [ ] Verify `known_devices.yaml` is now ignored
- [ ] Verify `*.jinja` files in `custom_templates/` are still tracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)