### PR TITLE
Address duplicate key issues in grocy.yaml

### DIFF
--- a/packages/zenos_ai/plugins/grocy/grocy.yaml
+++ b/packages/zenos_ai/plugins/grocy/grocy.yaml
@@ -80,13 +80,11 @@ rest_command:
 
 script:
   zen_dojotools_grocy_advanced:
-    alias: Zen DojoTools Grocy Advanced
-    description: >-
-      Internal Grocy REST dispatcher used by zen_dojotools_grocy_helper.
-      Handles GET/POST/PUT/DELETE against the Grocy API with pagination,
-      search, and payload routing. Not intended for direct invocation.
-    mode: single
-    icon: mdi:api
+    #description: >-
+    #  Internal Grocy REST dispatcher used by zen_dojotools_grocy_helper.
+    #  Handles GET/POST/PUT/DELETE against the Grocy API with pagination,
+    #  search, and payload routing. Not intended for direct invocation.
+    #icon: mdi:api
     sequence:
     - variables:
         inv_action_type: "{% set v = action_type | default('help') %} {% if v in ['post','create']


### PR DESCRIPTION
@TODO I was not sure what you wished to retain in regard to the description and icon so I have retained the variants as commented lines to be audited/merged/removed

- YAML file packages/zenos_ai/plugins/grocy/grocy.yaml contains duplicate key "alias". Check lines 82 and 358
- YAML file packages/zenos_ai/plugins/grocy/grocy.yaml contains duplicate key "description". Check lines 83 and 359
- YAML file packages/zenos_ai/plugins/grocy/grocy.yaml contains duplicate key "mode". Check lines 87 and 432
- YAML file packages/zenos_ai/plugins/grocy/grocy.yaml contains duplicate key "icon". Check lines 88 and 433