### PR TITLE
2026-03-08-Hardcoded-AI-Reasoning-Task

### DIFF
--- a/packages/zenos_ai/dojotools/dojotools_summarizers.yaml
+++ b/packages/zenos_ai/dojotools/dojotools_summarizers.yaml
@@ -255,7 +255,7 @@ script:
         data:
           task_name: SuperSummary Monk
           instructions: "{{ prompt }}"
-          entity_id: ai_task.gpt_oss_20b_local_ai_task
+          entity_id: "{{ states('input_text.zenos_reasoning_task' }}"
         response_variable: monk_response
 
       - alias: Extract zen summary from monk response
@@ -533,7 +533,7 @@ script:
         data:
           task_name: "{{ kung_fu_component_id | title }} Monk"
           instructions: "{{ prompt }}"
-          entity_id: ai_task.gpt_oss_20b_local_ai_task
+          entity_id: "{{ states('input_text.zenos_reasoning_task' }}"
         response_variable: monk_response
 
       - alias: Extract kata summary from monk response

--- a/packages/zenos_ai/flynn.yaml
+++ b/packages/zenos_ai/flynn.yaml
@@ -22,6 +22,12 @@ input_text:
     max: 255
     initial: "conversation.openai_friday_zen1_rc1"
 
+  zenos_reasoning_task:
+    name: "ZenOS: Reasoning Task"
+    icon: mdi:robot
+    max: 255
+    initial: "ai_task.gpt_oss_20b_local_ai_task"
+
   zenos_household_name:
     name: "ZenOS: Household Name"
     icon: mdi:home

--- a/zenos_ai/docs/architecture/04_Cognitive_Data_Flow.md
+++ b/zenos_ai/docs/architecture/04_Cognitive_Data_Flow.md
@@ -396,6 +396,8 @@ For a given Kung Fu component, Ninja Summarizer:
 
 5. Invokes an `ai_task.generate_data` entity (e.g., `ai_task.gpt_oss_20b_local_ai_task`) with that prompt.
 
+   *This `ai_task` is a user defined task defined by input_text.zenos_reasoning_task* 
+
 6. Receives a strictly JSON result in `monk_response.data`.
 
 7. Optionally writes the result as a new drawer under `sensor.zen_kata_storage_cabinet`, keyed by the component slug.

--- a/zenos_ai/docs/architecture/05_Reasoning_and_Kata_Design.md
+++ b/zenos_ai/docs/architecture/05_Reasoning_and_Kata_Design.md
@@ -207,6 +207,8 @@ The AI worker is then instructed to **fill the `structure`** in a manner consist
 
 An `ai_task` such as `ai_task.gpt_oss_20b_local_ai_task` is invoked with this prompt object. The Home Assistant AI Task integration ensures that:
 
+*(This `ai_task` is a user defined task defined by input_text.zenos_reasoning_task)*
+
 * the prompt is serialized as JSON,
 * the response is treated as JSON-first (data-only),
 * the response is captured as `monk_response.data` within Home Assistant.


### PR DESCRIPTION
https://github.com/nathan-curtis/zenos-ai/issues/46

Fixes #46

Implement an additional configuration variable for the reasoning ai_task, implemented as a helper

Assign in code where applicable (dojotools_summarizers.yaml)

Update documentation