### PR TITLE
2026-03-09-Prevent-Create-Existing-Label

### DIFF
--- a/packages/zenos_ai/dojotools/dojotools_labels.yaml
+++ b/packages/zenos_ai/dojotools/dojotools_labels.yaml
@@ -84,12 +84,22 @@ script:
         - repeat:
             for_each: '{{ target_labels }}'
             sequence:
-            - action: homeassistant.create_label
-              metadata: {}
-              data:
-                name: '{{ repeat.item }}'
-                description: tbd
-                color: primary
+            - variables:
+                new_name: "{{- repeat.item -}}"
+                new_id: "{{- new_name | slugify(separator='_') -}}"
+                label_exists: >
+                  {{-
+                    (label_id(new_name) is not none)
+                    or (label_name(new_id) is not none)
+                  -}}
+            - if: "{{ not label_exists}}"
+              then:
+              - action: homeassistant.create_label
+                metadata: {}
+                data:
+                  name: '{{ repeat.item }}'
+                  description: tbd
+                  color: primary
         - variables:
             created_count: '{{ target_labels | count }}'
             response:


### PR DESCRIPTION
Current create labels script does not verify the existence of labels correctly.

This implements a JIT check to determine if the label exists and only attempt creation if it does not

The existing failure of logic is because the to_create: variable is populated by checking existence by comparing label_names with existing label_ids

This is a Hack and should be addressed comprehensively

Here is the source of the issue:
```YAML
        - variables:
            to_create: "[{% for label in user_labels if label not in label_index %}\n
              \ \"{{ label }}\"{% if not loop.last %},{% endif %}\n{% endfor %}]"
```
Here is the quick fix solution
```YAML
        - repeat:
            for_each: '{{ target_labels }}'
            sequence:
            - variables:
                new_name: "{{- repeat.item -}}"
                new_id: "{{- new_name | slugify(separator='_') -}}"
                label_exists: >
                  {{-
                    (label_id(new_name) is not none)
                    or (label_name(new_id) is not none)
                  -}}
            - if: "{{ not label_exists}}"
              then:
              - action: homeassistant.create_label
                metadata: {}
                data:
                  name: '{{ repeat.item }}'
                  description: tbd
                  color: primary
```