### PR TITLE
2026-03-11-volume-redirector-fix

### DIFF
--- a/packages/zenos_ai/zenos_cabinets.yaml
+++ b/packages/zenos_ai/zenos_cabinets.yaml
@@ -25,16 +25,16 @@ template:
   ###########################################################################
 
   - trigger:
-      - platform: event
+      - trigger: event
         event_type: set_variable_zenos_system_cabinet
-      - platform: event
+      - trigger: event
         event_type: remove_variable_zenos_system_cabinet
-      - platform: event
+      - trigger: event
         event_type: clear_variables_zenos_system_cabinet
     action:
       - if: "{{ this.attributes.get('log_events', true) }}"
         then:
-          - service: logbook.log
+          - action: logbook.log
             data:
               name: "{{ trigger.event.event_type }}"
               message: >
@@ -60,7 +60,7 @@ template:
             false
           {% endif %}
         then:
-          - service: logbook.log
+          - action: logbook.log
             data:
               name: "{{ this.name }} — WRITE BLOCKED"
               message: >
@@ -99,16 +99,16 @@ template:
             {% endif %}
 
   - trigger:
-      - platform: event
+      - trigger: event
         event_type: set_variable_zenos_system_history_cabinet
-      - platform: event
+      - trigger: event
         event_type: remove_variable_zenos_system_history_cabinet
-      - platform: event
+      - trigger: event
         event_type: clear_variables_zenos_system_history_cabinet
     action:
       - if: "{{ this.attributes.get('log_events', true) }}"
         then:
-          - service: logbook.log
+          - action: logbook.log
             data:
               name: "{{ trigger.event.event_type }}"
               message: >
@@ -134,7 +134,7 @@ template:
             false
           {% endif %}
         then:
-          - service: logbook.log
+          - action: logbook.log
             data:
               name: "{{ this.name }} — WRITE BLOCKED"
               message: >
@@ -173,16 +173,16 @@ template:
             {% endif %}
 
   - trigger:
-      - platform: event
+      - trigger: event
         event_type: set_variable_zenos_zen_dojo_cabinet
-      - platform: event
+      - trigger: event
         event_type: remove_variable_zenos_zen_dojo_cabinet
-      - platform: event
+      - trigger: event
         event_type: clear_variables_zenos_zen_dojo_cabinet
     action:
       - if: "{{ this.attributes.get('log_events', true) }}"
         then:
-          - service: logbook.log
+          - action: logbook.log
             data:
               name: "{{ trigger.event.event_type }}"
               message: >
@@ -208,7 +208,7 @@ template:
             false
           {% endif %}
         then:
-          - service: logbook.log
+          - action: logbook.log
             data:
               name: "{{ this.name }} — WRITE BLOCKED"
               message: >
@@ -247,16 +247,16 @@ template:
             {% endif %}
 
   - trigger:
-      - platform: event
+      - trigger: event
         event_type: set_variable_zenos_zen_kata_cabinet
-      - platform: event
+      - trigger: event
         event_type: remove_variable_zenos_zen_kata_cabinet
-      - platform: event
+      - trigger: event
         event_type: clear_variables_zenos_zen_kata_cabinet
     action:
       - if: "{{ this.attributes.get('log_events', true) }}"
         then:
-          - service: logbook.log
+          - action: logbook.log
             data:
               name: "{{ trigger.event.event_type }}"
               message: >
@@ -282,7 +282,7 @@ template:
             false
           {% endif %}
         then:
-          - service: logbook.log
+          - action: logbook.log
             data:
               name: "{{ this.name }} — WRITE BLOCKED"
               message: >
@@ -321,16 +321,16 @@ template:
             {% endif %}
 
   - trigger:
-      - platform: event
+      - trigger: event
         event_type: set_variable_zenos_zen_history_cabinet
-      - platform: event
+      - trigger: event
         event_type: remove_variable_zenos_zen_history_cabinet
-      - platform: event
+      - trigger: event
         event_type: clear_variables_zenos_zen_history_cabinet
     action:
       - if: "{{ this.attributes.get('log_events', true) }}"
         then:
-          - service: logbook.log
+          - action: logbook.log
             data:
               name: "{{ trigger.event.event_type }}"
               message: >
@@ -356,7 +356,7 @@ template:
             false
           {% endif %}
         then:
-          - service: logbook.log
+          - action: logbook.log
             data:
               name: "{{ this.name }} — WRITE BLOCKED"
               message: >
@@ -395,16 +395,16 @@ template:
             {% endif %}
 
   - trigger:
-      - platform: event
+      - trigger: event
         event_type: set_variable_zenos_zen_scratchpad_cabinet
-      - platform: event
+      - trigger: event
         event_type: remove_variable_zenos_zen_scratchpad_cabinet
-      - platform: event
+      - trigger: event
         event_type: clear_variables_zenos_zen_scratchpad_cabinet
     action:
       - if: "{{ this.attributes.get('log_events', true) }}"
         then:
-          - service: logbook.log
+          - action: logbook.log
             data:
               name: "{{ trigger.event.event_type }}"
               message: >
@@ -430,7 +430,7 @@ template:
             false
           {% endif %}
         then:
-          - service: logbook.log
+          - action: logbook.log
             data:
               name: "{{ this.name }} — WRITE BLOCKED"
               message: >
@@ -473,16 +473,16 @@ template:
   ###########################################################################
 
   - trigger:
-      - platform: event
+      - trigger: event
         event_type: set_variable_zenos_default_household_cabinet
-      - platform: event
+      - trigger: event
         event_type: remove_variable_zenos_default_household_cabinet
-      - platform: event
+      - trigger: event
         event_type: clear_variables_zenos_default_household_cabinet
     action:
       - if: "{{ this.attributes.get('log_events', true) }}"
         then:
-          - service: logbook.log
+          - action: logbook.log
             data:
               name: "{{ trigger.event.event_type }}"
               message: >
@@ -508,7 +508,7 @@ template:
             false
           {% endif %}
         then:
-          - service: logbook.log
+          - action: logbook.log
             data:
               name: "{{ this.name }} — WRITE BLOCKED"
               message: >
@@ -547,16 +547,16 @@ template:
             {% endif %}
 
   - trigger:
-      - platform: event
+      - trigger: event
         event_type: set_variable_zenos_default_household_history_cabinet
-      - platform: event
+      - trigger: event
         event_type: remove_variable_zenos_default_household_history_cabinet
-      - platform: event
+      - trigger: event
         event_type: clear_variables_zenos_default_household_history_cabinet
     action:
       - if: "{{ this.attributes.get('log_events', true) }}"
         then:
-          - service: logbook.log
+          - action: logbook.log
             data:
               name: "{{ trigger.event.event_type }}"
               message: >
@@ -582,7 +582,7 @@ template:
             false
           {% endif %}
         then:
-          - service: logbook.log
+          - action: logbook.log
             data:
               name: "{{ this.name }} — WRITE BLOCKED"
               message: >
@@ -625,16 +625,16 @@ template:
   ###########################################################################
 
   - trigger:
-      - platform: event
+      - trigger: event
         event_type: set_variable_zenos_default_family_cabinet
-      - platform: event
+      - trigger: event
         event_type: remove_variable_zenos_default_family_cabinet
-      - platform: event
+      - trigger: event
         event_type: clear_variables_zenos_default_family_cabinet
     action:
       - if: "{{ this.attributes.get('log_events', true) }}"
         then:
-          - service: logbook.log
+          - action: logbook.log
             data:
               name: "{{ trigger.event.event_type }}"
               message: >
@@ -660,7 +660,7 @@ template:
             false
           {% endif %}
         then:
-          - service: logbook.log
+          - action: logbook.log
             data:
               name: "{{ this.name }} — WRITE BLOCKED"
               message: >
@@ -699,16 +699,16 @@ template:
             {% endif %}
 
   - trigger:
-      - platform: event
+      - trigger: event
         event_type: set_variable_zenos_default_family_history_cabinet
-      - platform: event
+      - trigger: event
         event_type: remove_variable_zenos_default_family_history_cabinet
-      - platform: event
+      - trigger: event
         event_type: clear_variables_zenos_default_family_history_cabinet
     action:
       - if: "{{ this.attributes.get('log_events', true) }}"
         then:
-          - service: logbook.log
+          - action: logbook.log
             data:
               name: "{{ trigger.event.event_type }}"
               message: >
@@ -734,7 +734,7 @@ template:
             false
           {% endif %}
         then:
-          - service: logbook.log
+          - action: logbook.log
             data:
               name: "{{ this.name }} — WRITE BLOCKED"
               message: >
@@ -777,16 +777,16 @@ template:
   ###########################################################################
 
   - trigger:
-      - platform: event
+      - trigger: event
         event_type: set_variable_zenos_default_user_cabinet
-      - platform: event
+      - trigger: event
         event_type: remove_variable_zenos_default_user_cabinet
-      - platform: event
+      - trigger: event
         event_type: clear_variables_zenos_default_user_cabinet
     action:
       - if: "{{ this.attributes.get('log_events', true) }}"
         then:
-          - service: logbook.log
+          - action: logbook.log
             data:
               name: "{{ trigger.event.event_type }}"
               message: >
@@ -812,7 +812,7 @@ template:
             false
           {% endif %}
         then:
-          - service: logbook.log
+          - action: logbook.log
             data:
               name: "{{ this.name }} — WRITE BLOCKED"
               message: >
@@ -851,16 +851,16 @@ template:
             {% endif %}
 
   - trigger:
-      - platform: event
+      - trigger: event
         event_type: set_variable_zenos_default_user_history_cabinet
-      - platform: event
+      - trigger: event
         event_type: remove_variable_zenos_default_user_history_cabinet
-      - platform: event
+      - trigger: event
         event_type: clear_variables_zenos_default_user_history_cabinet
     action:
       - if: "{{ this.attributes.get('log_events', true) }}"
         then:
-          - service: logbook.log
+          - action: logbook.log
             data:
               name: "{{ trigger.event.event_type }}"
               message: >
@@ -886,7 +886,7 @@ template:
             false
           {% endif %}
         then:
-          - service: logbook.log
+          - action: logbook.log
             data:
               name: "{{ this.name }} — WRITE BLOCKED"
               message: >
@@ -929,16 +929,16 @@ template:
   ###########################################################################
 
   - trigger:
-      - platform: event
+      - trigger: event
         event_type: set_variable_zenos_default_ai_user_cabinet
-      - platform: event
+      - trigger: event
         event_type: remove_variable_zenos_default_ai_user_cabinet
-      - platform: event
+      - trigger: event
         event_type: clear_variables_zenos_default_ai_user_cabinet
     action:
       - if: "{{ this.attributes.get('log_events', true) }}"
         then:
-          - service: logbook.log
+          - action: logbook.log
             data:
               name: "{{ trigger.event.event_type }}"
               message: >
@@ -964,7 +964,7 @@ template:
             false
           {% endif %}
         then:
-          - service: logbook.log
+          - action: logbook.log
             data:
               name: "{{ this.name }} — WRITE BLOCKED"
               message: >
@@ -1003,16 +1003,16 @@ template:
             {% endif %}
 
   - trigger:
-      - platform: event
+      - trigger: event
         event_type: set_variable_zenos_default_ai_user_history_cabinet
-      - platform: event
+      - trigger: event
         event_type: remove_variable_zenos_default_ai_user_history_cabinet
-      - platform: event
+      - trigger: event
         event_type: clear_variables_zenos_default_ai_user_history_cabinet
     action:
       - if: "{{ this.attributes.get('log_events', true) }}"
         then:
-          - service: logbook.log
+          - action: logbook.log
             data:
               name: "{{ trigger.event.event_type }}"
               message: >
@@ -1038,7 +1038,7 @@ template:
             false
           {% endif %}
         then:
-          - service: logbook.log
+          - action: logbook.log
             data:
               name: "{{ this.name }} — WRITE BLOCKED"
               message: >
@@ -1078,7 +1078,8 @@ template:
 
 
 automation:
-  alias: Zen DojoTools Volume Redirector
+- alias: Zen DojoTools Volume Redirector
+  id: zen_dojotools_volume_redirector
   description: >
     DojoTools Volume Redirector — ZENOS Edition (v4.0.0 RC2)
     Clean switchboard redirector for canonical Ring-0 ZENOS cabinets only.
@@ -1779,6 +1780,7 @@ automation:
         - condition: template
           value_template: "{{ routing_status == 'success' }}"
       then:
+        # @todo - declare variable 'event_data' and reuse where it's duplicated here
         - event: dojo_volume_redirector_result
           event_data:
             status: success


### PR DESCRIPTION
- Make automations in package list elements (modern standards)
- Add id to automation to prevent creation of automation.zen_dojotools_volume_redirector_2 after removing and reinstalling zenos_ai package
- switch `platform: event` to `trigger: event`
- switch `service: logbook.log` to `action: logbook.log`