### PR TITLE
2026 03 12 slots labels source of truth

### DIFF
--- a/custom_templates/zenos_ai/zenos_health.jinja
+++ b/custom_templates/zenos_ai/zenos_health.jinja
@@ -81,6 +81,7 @@ Provides mapping of slots to default entities
     {{- required_label_ids()
     | from_json([])
     | select('in', labels())
+    | list
     | to_json(pretty_print=true) -}}
 {%- endmacro -%}
 
@@ -89,6 +90,7 @@ Provides mapping of slots to default entities
     {{- required_label_ids()
     | from_json([])
     | reject('in', labels())
+    | list
     | to_json(pretty_print=true) -}}
 {%- endmacro -%}
 

--- a/custom_templates/zenos_ai/zenos_health.jinja
+++ b/custom_templates/zenos_ai/zenos_health.jinja
@@ -1,0 +1,308 @@
+{#-
+slot_to_label()
+Provides mapping of slots to names
+-#}
+{%- macro slot_to_label() -%}
+    {{- {
+        'system':            'Zen System Cabinet',
+        'dojo':              'Zen Dojo Cabinet',
+        'kata':              'Zen Kata Cabinet',
+        'household':         'Zen Household Cabinet',
+        'default_household': 'Zen Default Household Cabinet',
+        'family':            'Zen Family Cabinet',
+        'default_family':    'Zen Default Family Cabinet',
+        'user':              'Zen User Cabinet',
+        'default_user':      'Zen Default User Cabinet',
+        'ai_user':           'Zen AI User Cabinet',
+        'default_ai_user':   'Zen Default AI User Cabinet',
+        'history':           'Zen History Cabinet',
+        'index':             'Zen Index Cabinet'
+    }
+    | to_json(pretty_print=true) -}}
+
+{%- endmacro -%}
+
+{#-
+slot_to_default_entity()
+Provides mapping of slots to default entities
+-#}
+{%- macro slot_to_label_id(slot) -%}
+    {%- set _slot_to_label = slot_to_label() | from_json([]) -%}
+    {%- set rv = zip(_slot_to_label.keys(), _slot_to_label.values()|map(slugify)) -%}
+    {{- rv | to_json(pretty_print=true) -}}
+{%- endmacro -%}
+
+{#-
+slot_to_default_entity()
+Provides mapping of slots to default entities
+-#}
+{%- macro slot_to_default_entity() -%}
+    {{- {
+        'system':            'sensor.zenos_system_cabinet',
+        'dojo':              'sensor.zenos_dojo_cabinet',
+        'kata':              'sensor.zenos_kata_cabinet',
+        'default_household': 'sensor.zenos_default_household_cabinet',
+        'default_family':    'sensor.zenos_default_family_cabinet',
+        'default_user':      'sensor.zenos_default_user_cabinet',
+        'default_ai_user':   'sensor.zenos_default_ai_user_cabinet',
+        'history':           'sensor.zenos_history_cabinet',
+        'index':             'sensor.zenos_scratchpad_cabinet'
+    }
+    | to_json(pretty_print=true) -}}
+
+{%- endmacro -%}
+
+
+{#- ################################################# -#}
+{%- macro required_labels() -%}
+    {%- set required = [
+        'Zen Cabinet','Zen System Cabinet','Zen Dojo Cabinet','Zen Kata Cabinet',
+        'Zen Default Household','Zen Default Household Cabinet',
+        'Zen Default Family','Zen Default Family Cabinet',
+        'Zen Default User Cabinet','Zen Default AI User Cabinet',
+        'Zen History Cabinet','Zen Index Cabinet'
+    ] -%}
+    {{- required | to_json(pretty_print=true) -}}
+{%- endmacro -%}
+
+{#- ################################################# -#}
+{%- macro required_label_ids() -%}
+    {{- required_labels()
+    | from_json([])
+    | map('slugify')
+    | list
+    | to_json(pretty_print=true) -}}
+{%- endmacro -%}
+
+{#- ################################################# -#}
+{%- macro existing_label_ids() -%}
+    {{- required_label_ids()
+    | from_json([])
+    | select('in', labels())
+    | to_json(pretty_print=true) -}}
+{%- endmacro -%}
+
+{#- ################################################# -#}
+{%- macro missing_label_ids() -%}
+    {{- required_label_ids()
+    | from_json([])
+    | reject('in', labels())
+    | to_json(pretty_print=true) -}}
+{%- endmacro -%}
+
+{#-
+#######################################################################
+# BROKEN / UNASSIGNED / UNHEALTHY LABEL IDS
+#######################################################################
+-#}
+{%- macro unassigned_label_ids() -%}
+    {#- Finds existing IDs -#}
+    {%- set _existing_label_ids = existing_label_ids() | from_json([]) -%}
+    {#- Count Entities for each -#}
+    {%- set _existing_label_ent_counts = _existing_label_ids | map('label_entities') | map('count') | list -%}
+    {#- combine results to dict of tuples -#}
+    {%- set _combined = zip(_existing_label_ids, _existing_label_ent_counts) | list -%}
+    {#- select any label with zero entities -#}
+    {%- set _unassigned = dict(_combined|selectattr('1','eq',0)) -%}
+    {#- return list of unassigned label_ids (the keys) -#}
+    {{- _unassigned.keys()|list | to_json(pretty_print=true) -}}
+{%- endmacro -%}
+
+{#- ################################################# -#}
+{%- macro unhealthy_label_ids() -%}
+    {%- set _existing_label_ids = existing_label_ids() | from_json([]) -%}
+    {%- set ns = namespace(unhealthy=[]) -%}
+
+    {%- for lid in _existing_label_ids -%}
+        {%- set ents = label_entities(lid) or [] -%}
+        {%- if ents | count > 0 -%}
+            {%- set bad = ents | selectattr('state','in',['unknown','unavailable']) | list -%}
+            {%- if bad | count > 0 -%}
+                {%- set ns.unhealthy = ns.unhealthy + [lid] -%}
+            {%- endif -%}
+        {%- endif -%}
+    {%- endfor -%}
+
+    {{- ns.unhealthy | to_json(pretty_print=true) -}}
+{%- endmacro -%}
+
+{#- ################################################# -#}
+{%- macro healthy_label_ids() -%}
+    {%- set ns = namespace(ok=[]) -%}
+    {%- for lid in existing_label_ids() | from_json([]) -%}
+        {%- set ents = label_entities(lid) or [] -%}
+        {%- if ents | count > 0 -%}
+            {%- set bad = ents | selectattr('state','in',['unavailable','unknown']) | list -%}
+            {%- if bad | count == 0 -%}
+                {%- set ns.ok = ns.ok + [lid] -%}
+            {%- endif -%}
+        {%- endif -%}
+    {%- endfor -%}
+    {{- ns.ok | to_json(pretty_print=true) -}}
+{%- endmacro -%}
+
+{#- ################################################# -#}
+{%- macro zen_label_health_state() -%}
+    {# Optional (not health-gated):
+             Instance: Zen Household, Zen Family, Zen User, Zen AI User
+             Instance cabinets: Zen User Cabinet, Zen AI User Cabinet
+             System: Zen Squirrel, Zen Fusion, Zen Health #}
+
+    {%- set _required_label_ids = required_label_ids() | from_json([]) -%}
+    {% set label_index = labels() %}
+
+    {% set ns = namespace(
+        missing = missing_label_ids() | from_json([]),
+        unassigned = [],
+        unhealthy = []
+    ) %}
+
+    {% for lid in required_ids %}
+
+        {# ----------------------------- #}
+        {# 1. Missing label entirely     #}
+        {# ----------------------------- #}
+        {% if lid not in label_index %}
+            {% set ns.missing = ns.missing + [lid] %}
+        {% else %}
+            {% set ents = label_entities(lid) or [] %}
+
+            {# -------------------------------- #}
+            {# 2. Unassigned: exists, 0 entities #}
+            {# -------------------------------- #}
+            {% if ents | count == 0 %}
+                {% set ns.unassigned = ns.unassigned + [lid] %}
+            {% else %}
+
+                {# ---------------------------------------- #}
+                {# 3. Unhealthy: one or more ents unavailable #}
+                {# ---------------------------------------- #}
+                {% set bad = ents
+                    | selectattr('state','in',['unavailable', 'unknown'])
+                    | list %}
+                {% if bad | count > 0 %}
+                    {% set ns.unhealthy = ns.unhealthy + [lid] %}
+                {% endif %}
+
+            {% endif %}
+        {% endif %}
+
+    {% endfor %}
+
+    {# ----------------------------- #}
+    {# PRIORITY: missing > unhealthy > unassigned > ok #}
+    {# ----------------------------- #}
+
+    {% if ns.missing | count > 0 %}
+        critical
+        {% elif ns.unhealthy | count > 0 %}
+        error
+        {% elif ns.unassigned | count > 0 %}
+        warn
+    {% else %}
+        ok
+    {% endif %}
+{%- endmacro -%}
+
+{#- ################################################# -#}
+{%- macro slots_all() -%}
+    {{- [
+        'system','dojo','kata',
+        'household','default_household',
+        'family','default_family',
+        'user','default_user',
+        'ai_user','default_ai_user',
+        'history','index'
+    ] | to_json(pretty_print=true) -}}
+{%- endmacro -%}
+
+{#- ################################################# -#}
+{%- macro slots_required() -%}
+    {{- [
+        'system','dojo','kata',
+        'default_household','default_family',
+        'default_user','default_ai_user'
+    ] | to_json(pretty_print=true) -}}
+{%- endmacro -%}
+
+{#- ################################################# -#}
+{%- macro slots_optional() -%}
+    {{- [
+        'household','family',
+        'user','ai_user',
+        'history','index'
+    ] | to_json(pretty_print=true) -}}
+{%- endmacro -%}
+
+{#- ################################################# -#}
+{%- macro zen_cabinet_health_state() -%}
+    {% set required = slots_required() | from_json() %}
+    {% set optional = slots_optional() | from_json() %}
+
+    {% set slot_to_label = slot_to_label() | from_json() %}
+
+    {% set parent_slug = 'Zen Cabinet' | slugify %}
+    {% set all_cabs = label_entities(parent_slug) | list %}
+    {% set label_index = labels() %}
+
+    {% set ns = namespace(
+        missing_req = [],
+        unassigned_req = [],
+        invalid_req = [],
+        unhealthy_req = [],
+        unhealthy_opt = []
+    ) %}
+
+    {# REQUIRED SLOTS: strict 1:1, label + cabinet health enforced #}
+    {% for slot in required %}
+        {% set label_slug = slot_to_label[slot] | slugify %}
+        {% set label_exists = label_slug in label_index %}
+        {% set ents = intersect(all_cabs, label_entities(label_slug) or []) | list %}
+        {% set bad = ents | selectattr('state','in',['unavailable','unknown']) | list %}
+
+        {% if not label_exists %}
+            {% set ns.missing_req = ns.missing_req + [slot] %}
+            {% elif ents | count == 0 %}
+            {% set ns.unassigned_req = ns.unassigned_req + [slot] %}
+            {% elif ents | count > 1 %}
+            {% set ns.invalid_req = ns.invalid_req + [slot] %}
+            {% elif bad | count > 0 %}
+            {% set ns.unhealthy_req = ns.unhealthy_req + [slot] %}
+        {% endif %}
+    {% endfor %}
+
+    {# OPTIONAL SLOTS: 0..N allowed, only health tracked #}
+    {% for slot in optional %}
+        {% set label_slug = slot_to_label[slot] | slugify %}
+        {% set ents = intersect(all_cabs, label_entities(label_slug) or []) | list %}
+        {% if ents | count > 0 %}
+            {% set bad = ents | selectattr('state','in',['unavailable','unknown']) | list %}
+            {% if bad | count > 0 %}
+                {% set ns.unhealthy_opt = ns.unhealthy_opt + [slot] %}
+            {% endif %}
+        {% endif %}
+    {% endfor %}
+
+    {# Priority (labels-aligned):
+             missing required  -> critical
+             invalid required  -> error
+             unhealthy required-> error
+             unassigned required -> warn
+             unhealthy optional  -> warn
+             else -> ok
+    #}
+    {% if ns.missing_req | count > 0 %}
+        critical
+        {% elif ns.invalid_req | count > 0 %}
+        error
+        {% elif ns.unhealthy_req | count > 0 %}
+        error
+        {% elif ns.unassigned_req | count > 0 %}
+        warn
+        {% elif ns.unhealthy_opt | count > 0 %}
+        warn
+    {% else %}
+        ok
+    {% endif %}
+{%- endmacro -%}
+

--- a/custom_templates/zenos_ai/zenos_health.jinja
+++ b/custom_templates/zenos_ai/zenos_health.jinja
@@ -55,7 +55,7 @@ Provides mapping of slots to default entities
 
 {#- ################################################# -#}
 {%- macro required_labels() -%}
-    {% set required = [
+    {%- set required = [
         'Zen Cabinet','Zen System Cabinet','Zen Dojo Cabinet','Zen Kata Cabinet',
         'Zen Default Household','Zen Default Household Cabinet',
         'Zen Default Family','Zen Default Family Cabinet',
@@ -63,7 +63,7 @@ Provides mapping of slots to default entities
         'Zen Household Cabinet','Zen Family Cabinet',
         'Zen User Cabinet','Zen AI User Cabinet',
         'Zen History Cabinet','Zen Index Cabinet'
-    ] %}
+    ] -%}
     {{- required | to_json(pretty_print=true) -}}
 {%- endmacro -%}
 
@@ -114,10 +114,8 @@ Provides mapping of slots to default entities
 
 {#- ################################################# -#}
 {%- macro unhealthy_label_ids() -%}
-    {%- set _existing_label_ids = existing_label_ids() | from_json([]) -%}
     {%- set ns = namespace(unhealthy=[]) -%}
-
-    {%- for lid in _existing_label_ids -%}
+    {%- for lid in existing_label_ids() | from_json([]) -%}
         {%- set ents = label_entities(lid) or [] -%}
         {%- if ents | count > 0 -%}
             {%- set bad = ents | selectattr('state','in',['unknown','unavailable']) | list -%}
@@ -145,67 +143,29 @@ Provides mapping of slots to default entities
     {{- ns.ok | to_json(pretty_print=true) -}}
 {%- endmacro -%}
 
+
 {#- ################################################# -#}
 {%- macro zen_label_health_state() -%}
-    {# Optional (not health-gated):
-             Instance: Zen Household, Zen Family, Zen User, Zen AI User
-             Instance cabinets: Zen User Cabinet, Zen AI User Cabinet
-             System: Zen Squirrel, Zen Fusion, Zen Health #}
 
-    {%- set _required_label_ids = required_label_ids() | from_json([]) -%}
-    {% set label_index = labels() %}
-
-    {% set ns = namespace(
+    {%- set ns = namespace(
         missing = missing_label_ids() | from_json([]),
-        unassigned = [],
-        unhealthy = []
-    ) %}
-
-    {% for lid in required_ids %}
-
-        {# ----------------------------- #}
-        {# 1. Missing label entirely     #}
-        {# ----------------------------- #}
-        {% if lid not in label_index %}
-            {% set ns.missing = ns.missing + [lid] %}
-        {% else %}
-            {% set ents = label_entities(lid) or [] %}
-
-            {# -------------------------------- #}
-            {# 2. Unassigned: exists, 0 entities #}
-            {# -------------------------------- #}
-            {% if ents | count == 0 %}
-                {% set ns.unassigned = ns.unassigned + [lid] %}
-            {% else %}
-
-                {# ---------------------------------------- #}
-                {# 3. Unhealthy: one or more ents unavailable #}
-                {# ---------------------------------------- #}
-                {% set bad = ents
-                    | selectattr('state','in',['unavailable', 'unknown'])
-                    | list %}
-                {% if bad | count > 0 %}
-                    {% set ns.unhealthy = ns.unhealthy + [lid] %}
-                {% endif %}
-
-            {% endif %}
-        {% endif %}
-
-    {% endfor %}
+        unassigned = unassigned_label_ids() | from_json([]),
+        unhealthy = unhealthy_label_ids() | from_json([])
+    ) -%}
 
     {# ----------------------------- #}
     {# PRIORITY: missing > unhealthy > unassigned > ok #}
     {# ----------------------------- #}
 
-    {% if ns.missing | count > 0 %}
+    {%- if ns.missing | count > 0 -%}
         critical
-        {% elif ns.unhealthy | count > 0 %}
+        {%- elif ns.unhealthy | count > 0 -%}
         error
-        {% elif ns.unassigned | count > 0 %}
+        {%- elif ns.unassigned | count > 0 -%}
         warn
-    {% else %}
+    {%- else -%}
         ok
-    {% endif %}
+    {%- endif -%}
 {%- endmacro -%}
 
 {#- ################################################# -#}
@@ -240,73 +200,73 @@ Provides mapping of slots to default entities
 
 {#- ################################################# -#}
 {%- macro zen_cabinet_health_state() -%}
-    {% set required = slots_required() | from_json() %}
-    {% set optional = slots_optional() | from_json() %}
+    {%- set required = slots_required() | from_json() -%}
+    {%- set optional = slots_optional() | from_json() -%}
 
-    {% set slot_to_label = slot_to_label() | from_json() %}
+    {%- set slot_to_label = slot_to_label() | from_json() -%}
 
-    {% set parent_slug = 'Zen Cabinet' | slugify %}
-    {% set all_cabs = label_entities(parent_slug) | list %}
-    {% set label_index = labels() %}
+    {%- set parent_slug = 'Zen Cabinet' | slugify -%}
+    {%- set all_cabs = label_entities(parent_slug) | list -%}
+    {%- set label_index = labels() -%}
 
-    {% set ns = namespace(
+    {%- set ns = namespace(
         missing_req = [],
         unassigned_req = [],
         invalid_req = [],
         unhealthy_req = [],
         unhealthy_opt = []
-    ) %}
+    ) -%}
 
     {# REQUIRED SLOTS: strict 1:1, label + cabinet health enforced #}
-    {% for slot in required %}
-        {% set label_slug = slot_to_label[slot] | slugify %}
-        {% set label_exists = label_slug in label_index %}
-        {% set ents = intersect(all_cabs, label_entities(label_slug) or []) | list %}
-        {% set bad = ents | selectattr('state','in',['unavailable','unknown']) | list %}
+    {%- for slot in required -%}
+        {%- set label_slug = slot_to_label[slot] | slugify -%}
+        {%- set label_exists = label_slug in label_index -%}
+        {%- set ents = intersect(all_cabs, label_entities(label_slug) or []) | list -%}
+        {%- set bad = ents | selectattr('state','in',['unavailable','unknown']) | list -%}
 
-        {% if not label_exists %}
-            {% set ns.missing_req = ns.missing_req + [slot] %}
-            {% elif ents | count == 0 %}
-            {% set ns.unassigned_req = ns.unassigned_req + [slot] %}
-            {% elif ents | count > 1 %}
-            {% set ns.invalid_req = ns.invalid_req + [slot] %}
-            {% elif bad | count > 0 %}
-            {% set ns.unhealthy_req = ns.unhealthy_req + [slot] %}
-        {% endif %}
-    {% endfor %}
+        {%- if not label_exists -%}
+            {%- set ns.missing_req = ns.missing_req + [slot] -%}
+            {%- elif ents | count == 0 -%}
+            {%- set ns.unassigned_req = ns.unassigned_req + [slot] -%}
+            {%- elif ents | count > 1 -%}
+            {%- set ns.invalid_req = ns.invalid_req + [slot] -%}
+            {%- elif bad | count > 0 -%}
+            {%- set ns.unhealthy_req = ns.unhealthy_req + [slot] -%}
+        {%- endif -%}
+    {%- endfor -%}
 
     {# OPTIONAL SLOTS: 0..N allowed, only health tracked #}
-    {% for slot in optional %}
-        {% set label_slug = slot_to_label[slot] | slugify %}
-        {% set ents = intersect(all_cabs, label_entities(label_slug) or []) | list %}
-        {% if ents | count > 0 %}
-            {% set bad = ents | selectattr('state','in',['unavailable','unknown']) | list %}
-            {% if bad | count > 0 %}
-                {% set ns.unhealthy_opt = ns.unhealthy_opt + [slot] %}
-            {% endif %}
-        {% endif %}
-    {% endfor %}
+    {%- for slot in optional -%}
+        {%- set label_slug = slot_to_label[slot] | slugify -%}
+        {%- set ents = intersect(all_cabs, label_entities(label_slug) or []) | list -%}
+        {%- if ents | count > 0 -%}
+            {%- set bad = ents | selectattr('state','in',['unavailable','unknown']) | list -%}
+            {%- if bad | count > 0 -%}
+                {%- set ns.unhealthy_opt = ns.unhealthy_opt + [slot] -%}
+            {%- endif -%}
+        {%- endif -%}
+    {%- endfor -%}
 
     {# Priority (labels-aligned):
-             missing required  -> critical
-             invalid required  -> error
-             unhealthy required-> error
-             unassigned required -> warn
-             unhealthy optional  -> warn
-             else -> ok
+missing required  -> critical
+invalid required  -> error
+unhealthy required-> error
+unassigned required -> warn
+unhealthy optional  -> warn
+else -> ok
     #}
-    {% if ns.missing_req | count > 0 %}
+    {%- if ns.missing_req | count > 0 -%}
         critical
-        {% elif ns.invalid_req | count > 0 %}
+        {%- elif ns.invalid_req | count > 0 -%}
         error
-        {% elif ns.unhealthy_req | count > 0 %}
+        {%- elif ns.unhealthy_req | count > 0 -%}
         error
-        {% elif ns.unassigned_req | count > 0 %}
+        {%- elif ns.unassigned_req | count > 0 -%}
         warn
-        {% elif ns.unhealthy_opt | count > 0 %}
+        {%- elif ns.unhealthy_opt | count > 0 -%}
         warn
-    {% else %}
+    {%- else -%}
         ok
-    {% endif %}
+    {%- endif -%}
 {%- endmacro -%}
 

--- a/custom_templates/zenos_ai/zenos_health.jinja
+++ b/custom_templates/zenos_ai/zenos_health.jinja
@@ -143,7 +143,6 @@ Provides mapping of slots to default entities
     {{- ns.ok | to_json(pretty_print=true) -}}
 {%- endmacro -%}
 
-
 {#- ################################################# -#}
 {%- macro zen_label_health_state() -%}
 

--- a/custom_templates/zenos_ai/zenos_health.jinja
+++ b/custom_templates/zenos_ai/zenos_health.jinja
@@ -55,13 +55,15 @@ Provides mapping of slots to default entities
 
 {#- ################################################# -#}
 {%- macro required_labels() -%}
-    {%- set required = [
+    {% set required = [
         'Zen Cabinet','Zen System Cabinet','Zen Dojo Cabinet','Zen Kata Cabinet',
         'Zen Default Household','Zen Default Household Cabinet',
         'Zen Default Family','Zen Default Family Cabinet',
         'Zen Default User Cabinet','Zen Default AI User Cabinet',
+        'Zen Household Cabinet','Zen Family Cabinet',
+        'Zen User Cabinet','Zen AI User Cabinet',
         'Zen History Cabinet','Zen Index Cabinet'
-    ] -%}
+    ] %}
     {{- required | to_json(pretty_print=true) -}}
 {%- endmacro -%}
 

--- a/packages/zenos_ai/flynn.yaml
+++ b/packages/zenos_ai/flynn.yaml
@@ -119,7 +119,7 @@ automation:
               - variables:
                   #raw_labels: "{{ state_attr('sensor.zen_label_health', 'required_labels') }}"
                   label_list: >-
-                    {%- import 'zenos/zenos_health.jinja' as HEALTH -%}
+                    {%- import 'zenos_ai/zenos_health.jinja' as HEALTH -%}
                     {{ HEALTH.required_labels() | from_json([]) }}
 
               # ---------------------------------------------
@@ -272,10 +272,10 @@ script:
     sequence:
       - variables:
           slot_to_label: >
-            {%- import 'zenos/zenos_health.jinja' as HEALTH -%}
+            {%- import 'zenos_ai/zenos_health.jinja' as HEALTH -%}
             {{- HEALTH.slot_to_label() | from_json() -}}
           slot_to_entity: >
-            {%- import 'zenos/zenos_health.jinja' as HEALTH -%}
+            {%- import 'zenos_ai/zenos_health.jinja' as HEALTH -%}
             {{- HEALTH.slot_to_default_entity() | from_json() -}}
 
 

--- a/packages/zenos_ai/flynn.yaml
+++ b/packages/zenos_ai/flynn.yaml
@@ -65,12 +65,31 @@ automation:
     triggers:
       - trigger: homeassistant
         event: start
+    # ---------------------------------------------------------
+    # Only trigger on state change of health cabinets (enum) - not on attributes
+    # @todo - might be able to use. not_to: unavailable
+    # ---------------------------------------------------------
       - trigger: state
         entity_id: sensor.zen_label_health
+        to:
+        - critical
+        - error
+        - warn
+        - ok
       - trigger: state
         entity_id: sensor.zen_cabinet_health
+        to:
+        - critical
+        - error
+        - warn
+        - ok
       - trigger: state
         entity_id: sensor.zen_monastery_health
+        to:
+        - critical
+        - error
+        - warn
+        - ok
     conditions: []
     actions:
       # Capture green state + OOBE state BEFORE delay
@@ -96,9 +115,9 @@ automation:
       # If oobe is pending we must walk through to Gate 3.5 even on green systems.
       - if: >
           {{ was_green
-             and states('sensor.zen_label_health')    == 'ok'
-             and states('sensor.zen_cabinet_health')  == 'ok'
-             and states('sensor.zen_monastery_health') in ['ok', 'warn']
+             and is_state('sensor.zen_label_health', 'ok')
+             and is_state('sensor.zen_cabinet_health', 'ok')
+             and is_state('sensor.zen_monastery_health', ['ok', 'warn'])
              and not _oobe_pending
              and 'kfc_template' in (state_attr(states('sensor.zen_dojo_cabinet_resolved'), 'variables') or {})
              and 'zen_template'  in (state_attr(states('sensor.zen_kata_cabinet_resolved'), 'variables') or {}) }}

--- a/packages/zenos_ai/flynn.yaml
+++ b/packages/zenos_ai/flynn.yaml
@@ -110,15 +110,14 @@ automation:
           - conditions: "{{ label_health == 'critical' }}"
             sequence:
               - variables:
-                  raw_labels: "{{ state_attr('sensor.zen_label_health', 'required_labels') }}"
+                  #raw_labels: "{{ state_attr('sensor.zen_label_health', 'required_labels') }}"
                   label_list: >-
-                    {% if raw_labels is string %}
-                      {{ raw_labels.split(', ') | map('trim') | list }}
-                    {% elif raw_labels is iterable %}
-                      {{ raw_labels | list }}
-                    {% else %}
-                      []
-                    {% endif %}
+                    {%- import 'zenos/zenos_health.jinja' as HEALTH -%}
+                    {{ HEALTH.required_labels() | from_json([]) }}
+
+              # ---------------------------------------------
+              # @related homeassistant.create_label
+              # ---------------------------------------------
               - alias: "Flynn: Create missing labels via DojoTools"
                 action: script.zen_dojotools_labels
                 data:
@@ -248,10 +247,14 @@ script:
     mode: single
     sequence:
       - variables:
-          slot_to_label_raw: "{{ state_attr('sensor.zen_cabinet_health', 'slot_to_label') }}"
-          slot_to_label: "{{ slot_to_label_raw if slot_to_label_raw is mapping else (slot_to_label_raw | from_json if slot_to_label_raw is string else {}) }}"
-          slot_to_entity_raw: "{{ state_attr('sensor.zen_cabinet_health', 'slot_to_default_entity') }}"
-          slot_to_entity: "{{ slot_to_entity_raw if slot_to_entity_raw is mapping else (slot_to_entity_raw | from_json if slot_to_entity_raw is string else {}) }}"
+          slot_to_label: >
+            {%- import 'zenos/zenos_health.jinja' as HEALTH -%}
+            {{- HEALTH.slot_to_label() | from_json() -}}
+          slot_to_entity: >
+            {%- import 'zenos/zenos_health.jinja' as HEALTH -%}
+            {{- HEALTH.slot_to_default_entity() | from_json() -}}
+
+
           parent_label: "Zen Cabinet"
           # Broad labels → default cabinet entity
           broad_labels:

--- a/packages/zenos_ai/sensors/zenos_agent_health.yaml
+++ b/packages/zenos_ai/sensors/zenos_agent_health.yaml
@@ -164,7 +164,7 @@ template:
           {%- set mon_st   = states('sensor.zen_monastery_health') %}
 
           {%- if label_st in ['critical','error'] or cab_st in ['critical','error'] %}
-            {%- if label_st == 'critical' or cab_st == 'critical' %}
+            {%- if 'critical' in [label_st, cab_st]  %}
               critical
             {%- else %}
               error

--- a/packages/zenos_ai/sensors/zenos_cabinet_health.yaml
+++ b/packages/zenos_ai/sensors/zenos_cabinet_health.yaml
@@ -24,97 +24,10 @@ template:
         #######################################################################
         # STATE
         #######################################################################
-        state: >-
-          {% set required = [
-            'system','dojo','kata',
-            'default_household','default_family',
-            'default_user','default_ai_user'
-          ] %}
-
-          {% set optional = [
-            'household','family','user','ai_user',
-            'history','index'
-          ] %}
-
-          {% set slot_to_label = {
-            'system':'Zen System Cabinet',
-            'dojo':'Zen Dojo Cabinet',
-            'kata':'Zen Kata Cabinet',
-            'household':'Zen Household Cabinet',
-            'default_household':'Zen Default Household Cabinet',
-            'family':'Zen Family Cabinet',
-            'default_family':'Zen Default Family Cabinet',
-            'user':'Zen User Cabinet',
-            'default_user':'Zen Default User Cabinet',
-            'ai_user':'Zen AI User Cabinet',
-            'default_ai_user':'Zen Default AI User Cabinet',
-            'history':'Zen History Cabinet',
-            'index':'Zen Index Cabinet'
-          } %}
-
-          {% set parent_slug = 'Zen Cabinet' | slugify %}
-          {% set all_cabs = label_entities(parent_slug) | list %}
-          {% set label_index = labels() %}
-
-          {% set ns = namespace(
-            missing_req = [],
-            unassigned_req = [],
-            invalid_req = [],
-            unhealthy_req = [],
-            unhealthy_opt = []
-          ) %}
-
-          {# REQUIRED SLOTS: strict 1:1, label + cabinet health enforced #}
-          {% for slot in required %}
-            {% set label_slug = slot_to_label[slot] | slugify %}
-            {% set label_exists = label_slug in label_index %}
-            {% set ents = intersect(all_cabs, label_entities(label_slug) or []) | list %}
-            {% set bad = ents | selectattr('state','in',['unavailable','unknown']) | list %}
-
-            {% if not label_exists %}
-              {% set ns.missing_req = ns.missing_req + [slot] %}
-            {% elif ents | count == 0 %}
-              {% set ns.unassigned_req = ns.unassigned_req + [slot] %}
-            {% elif ents | count > 1 %}
-              {% set ns.invalid_req = ns.invalid_req + [slot] %}
-            {% elif bad | count > 0 %}
-              {% set ns.unhealthy_req = ns.unhealthy_req + [slot] %}
-            {% endif %}
-          {% endfor %}
-
-          {# OPTIONAL SLOTS: 0..N allowed, only health tracked #}
-          {% for slot in optional %}
-            {% set label_slug = slot_to_label[slot] | slugify %}
-            {% set ents = intersect(all_cabs, label_entities(label_slug) or []) | list %}
-            {% if ents | count > 0 %}
-              {% set bad = ents | selectattr('state','in',['unavailable','unknown']) | list %}
-              {% if bad | count > 0 %}
-                {% set ns.unhealthy_opt = ns.unhealthy_opt + [slot] %}
-              {% endif %}
-            {% endif %}
-          {% endfor %}
-
-          {# Priority (labels-aligned):
-             missing required  -> critical
-             invalid required  -> error
-             unhealthy required-> error
-             unassigned required -> warn
-             unhealthy optional  -> warn
-             else -> ok
-          #}
-          {% if ns.missing_req | count > 0 %}
-            critical
-          {% elif ns.invalid_req | count > 0 %}
-            error
-          {% elif ns.unhealthy_req | count > 0 %}
-            error
-          {% elif ns.unassigned_req | count > 0 %}
-            warn
-          {% elif ns.unhealthy_opt | count > 0 %}
-            warn
-          {% else %}
-            ok
-          {% endif %}
+        state: >
+          {%- import 'zenos/zenos_health.jinja' as HEALTH -%}
+          {{- HEALTH.zen_cabinet_health_state() -}}
+          
 
         #######################################################################
         # ATTRIBUTES
@@ -144,46 +57,21 @@ template:
           #####################################################################
           # REQUIRED + OPTIONAL
           #####################################################################
-          required_cabinets: >-
-            {{ [
-              'system','dojo','kata',
-              'default_household','default_family',
-              'default_user','default_ai_user'
-            ] }}
+          required_cabinets: >
+            {%- import 'zenos/zenos_health.jinja' as HEALTH -%}
+            {{ HEALTH.slots_required() | from_json() }}
 
           optional_cabinets: >-
-            {{ [
-              'household','family','user','ai_user',
-              'history','index'
-            ] }}
+            {%- import 'zenos/zenos_health.jinja' as HEALTH -%}
+            {{ HEALTH.slots_optional() | from_json() }}
 
           #####################################################################
           # EXISTING CABINETS (BY SLOT)
           #####################################################################
           existing_cabinets: >-
-            {% set slots = [
-              'system','dojo','kata',
-              'household','default_household',
-              'family','default_family',
-              'user','default_user',
-              'ai_user','default_ai_user',
-              'history','index'
-            ] %}
-            {% set slot_to_label = {
-              'system':'Zen System Cabinet',
-              'dojo':'Zen Dojo Cabinet',
-              'kata':'Zen Kata Cabinet',
-              'household':'Zen Household Cabinet',
-              'default_household':'Zen Default Household Cabinet',
-              'family':'Zen Family Cabinet',
-              'default_family':'Zen Default Family Cabinet',
-              'user':'Zen User Cabinet',
-              'default_user':'Zen Default User Cabinet',
-              'ai_user':'Zen AI User Cabinet',
-              'default_ai_user':'Zen Default AI User Cabinet',
-              'history':'Zen History Cabinet',
-              'index':'Zen Index Cabinet'
-            } %}
+            {%- import 'zenos/zenos_health.jinja' as HEALTH -%}
+            {% set slots = HEALTH.slots_all() | from_json() %}
+            {% set slot_to_label = HEALTH.slot_to_label() | from_json() %}
             {% set all_cabs = label_entities('Zen Cabinet' | slugify) | list %}
             {% set ns = namespace(found=[]) %}
 
@@ -201,20 +89,10 @@ template:
           # MISSING REQUIRED CABINETS (LABEL OR ASSIGNMENT)
           #####################################################################
           missing_cabinets: >-
-            {% set required = [
-              'system','dojo','kata',
-              'default_household','default_family',
-              'default_user','default_ai_user'
-            ] %}
-            {% set slot_to_label = {
-              'system':'Zen System Cabinet',
-              'dojo':'Zen Dojo Cabinet',
-              'kata':'Zen Kata Cabinet',
-              'default_household':'Zen Default Household Cabinet',
-              'default_family':'Zen Default Family Cabinet',
-              'default_user':'Zen Default User Cabinet',
-              'default_ai_user':'Zen Default AI User Cabinet'
-            } %}
+            {%- import 'zenos/zenos_health.jinja' as HEALTH -%}
+            {% set required = HEALTH.slots_required() %}
+            {% set slot_to_label = HEALTH.slot_to_label() | from_json() %}
+            
             {% set parent_slug = 'Zen Cabinet' | slugify %}
             {% set all_cabs = label_entities(parent_slug) | list %}
             {% set label_index = labels() %}
@@ -235,20 +113,10 @@ template:
           # INVALID MULTIPLES (REQUIRED ONLY)
           #####################################################################
           invalid_multiples: >-
-            {% set required = [
-              'system','dojo','kata',
-              'default_household','default_family',
-              'default_user','default_ai_user'
-            ] %}
-            {% set slot_to_label = {
-              'system':'Zen System Cabinet',
-              'dojo':'Zen Dojo Cabinet',
-              'kata':'Zen Kata Cabinet',
-              'default_household':'Zen Default Household Cabinet',
-              'default_family':'Zen Default Family Cabinet',
-              'default_user':'Zen Default User Cabinet',
-              'default_ai_user':'Zen Default AI User Cabinet'
-            } %}
+            {%- import 'zenos/zenos_health.jinja' as HEALTH -%}
+            {% set required = HEALTH.slots_required() %}
+            {% set slot_to_label = HEALTH.slot_to_label() | from_json() %}
+
             {% set parent_slug = 'Zen Cabinet' | slugify %}
             {% set all_cabs = label_entities(parent_slug) | list %}
             {% set ns = namespace(dupe=[]) %}
@@ -267,29 +135,9 @@ template:
           # SLOT ENTITIES (FULL MAP)
           #####################################################################
           slot_entities: >-
-            {% set slots = [
-              'system','dojo','kata',
-              'household','default_household',
-              'family','default_family',
-              'user','default_user',
-              'ai_user','default_ai_user',
-              'history','index'
-            ] %}
-            {% set slot_to_label = {
-              'system':'Zen System Cabinet',
-              'dojo':'Zen Dojo Cabinet',
-              'kata':'Zen Kata Cabinet',
-              'household':'Zen Household Cabinet',
-              'default_household':'Zen Default Household Cabinet',
-              'family':'Zen Family Cabinet',
-              'default_family':'Zen Default Family Cabinet',
-              'user':'Zen User Cabinet',
-              'default_user':'Zen Default User Cabinet',
-              'ai_user':'Zen AI User Cabinet',
-              'default_ai_user':'Zen Default AI User Cabinet',
-              'history':'Zen History Cabinet',
-              'index':'Zen Index Cabinet'
-            } %}
+            {%- import 'zenos/zenos_health.jinja' as HEALTH -%}
+            {% set slots = HEALTH.slots_all() | from_json() %}
+            {% set slot_to_label = HEALTH.slot_to_label() | from_json() %}
             {% set all_cabs = label_entities('Zen Cabinet' | slugify) | list %}
             {% set ns = namespace(m={}) %}
 
@@ -305,31 +153,11 @@ template:
           # RESOLVER SUGGESTIONS (BY SLOT)
           #####################################################################
           resolver_suggestions: >-
-            {% set required = [
-              'system','dojo','kata',
-              'default_household','default_family',
-              'default_user','default_ai_user'
-            ] %}
-            {% set optional = [
-              'household','family','user','ai_user',
-              'history','index'
-            ] %}
-            {% set slot_to_label = {
-              'system':'Zen System Cabinet',
-              'dojo':'Zen Dojo Cabinet',
-              'kata':'Zen Kata Cabinet',
-              'household':'Zen Household Cabinet',
-              'default_household':'Zen Default Household Cabinet',
-              'family':'Zen Family Cabinet',
-              'default_family':'Zen Default Family Cabinet',
-              'user':'Zen User Cabinet',
-              'default_user':'Zen Default User Cabinet',
-              'ai_user':'Zen AI User Cabinet',
-              'default_ai_user':'Zen Default AI User Cabinet',
-              'history':'Zen History Cabinet',
-              'index':'Zen Index Cabinet'
-            } %}
-            {% set parent_slug = 'Zen Cabinet' | slugify %}
+            {%- import 'zenos/zenos_health.jinja' as HEALTH -%}
+            {% set required      = HEALTH.slots_required() | from_json() %}
+            {% set optional      = HEALTH.slots_optional() | from_json() %}
+            {% set slot_to_label = HEALTH.slot_to_label() | from_json() %}
+            {% set parent_slug   = 'Zen Cabinet' | slugify %}
             {% set all_cabs = label_entities(parent_slug) | list %}
             {% set label_index = labels() %}
             {% set ns = namespace(s={}) %}
@@ -361,37 +189,15 @@ template:
           #####################################################################
           # SLOT → LABEL MAPPING (single source of truth for Flynn)
           #####################################################################
-          slot_to_label: >-
-            {{ {
-              'system':'Zen System Cabinet',
-              'dojo':'Zen Dojo Cabinet',
-              'kata':'Zen Kata Cabinet',
-              'household':'Zen Household Cabinet',
-              'default_household':'Zen Default Household Cabinet',
-              'family':'Zen Family Cabinet',
-              'default_family':'Zen Default Family Cabinet',
-              'user':'Zen User Cabinet',
-              'default_user':'Zen Default User Cabinet',
-              'ai_user':'Zen AI User Cabinet',
-              'default_ai_user':'Zen Default AI User Cabinet',
-              'history':'Zen History Cabinet',
-              'index':'Zen Index Cabinet'
-            } | tojson }}
+          slot_to_label: >
+            {%- import 'zenos/zenos_health.jinja' as HEALTH -%}
+            {{- HEALTH.slot_to_label() | from_json({}) -}}
 
           #####################################################################
           # SLOT → DEFAULT ENTITY (canonical package entity IDs for Flynn)
           #####################################################################
-          slot_to_default_entity: >-
-            {{ {
-              'system':'sensor.zenos_system_cabinet',
-              'dojo':'sensor.zenos_dojo_cabinet',
-              'kata':'sensor.zenos_kata_cabinet',
-              'default_household':'sensor.zenos_default_household_cabinet',
-              'default_family':'sensor.zenos_default_family_cabinet',
-              'default_user':'sensor.zenos_default_user_cabinet',
-              'default_ai_user':'sensor.zenos_default_ai_user_cabinet',
-              'history':'sensor.zenos_history_cabinet',
-              'index':'sensor.zenos_scratchpad_cabinet'
-            } | tojson }}
+          slot_to_default_entity: >
+            {%- import 'zenos/zenos_health.jinja' as HEALTH -%}
+            {{- HEALTH.slot_to_default_entity() | from_json({}) -}}
 
           timestamp: "{{ now().isoformat() }}"

--- a/packages/zenos_ai/sensors/zenos_cabinet_health.yaml
+++ b/packages/zenos_ai/sensors/zenos_cabinet_health.yaml
@@ -26,7 +26,7 @@ template:
         #######################################################################
         state: >
           {%- import 'zenos_ai/zenos_health.jinja' as HEALTH -%}
-          {{- HEALTH.zen_cabinet_health_state() | from_json() -}}
+          {{- HEALTH.zen_cabinet_health_state()  -}}
           
 
         #######################################################################

--- a/packages/zenos_ai/sensors/zenos_cabinet_health.yaml
+++ b/packages/zenos_ai/sensors/zenos_cabinet_health.yaml
@@ -25,7 +25,7 @@ template:
         # STATE
         #######################################################################
         state: >
-          {%- import 'zenos/zenos_health.jinja' as HEALTH -%}
+          {%- import 'zenos_ai/zenos_health.jinja' as HEALTH -%}
           {{- HEALTH.zen_cabinet_health_state() -}}
           
 
@@ -58,18 +58,18 @@ template:
           # REQUIRED + OPTIONAL
           #####################################################################
           required_cabinets: >
-            {%- import 'zenos/zenos_health.jinja' as HEALTH -%}
+            {%- import 'zenos_ai/zenos_health.jinja' as HEALTH -%}
             {{ HEALTH.slots_required() | from_json() }}
 
           optional_cabinets: >-
-            {%- import 'zenos/zenos_health.jinja' as HEALTH -%}
+            {%- import 'zenos_ai/zenos_health.jinja' as HEALTH -%}
             {{ HEALTH.slots_optional() | from_json() }}
 
           #####################################################################
           # EXISTING CABINETS (BY SLOT)
           #####################################################################
           existing_cabinets: >-
-            {%- import 'zenos/zenos_health.jinja' as HEALTH -%}
+            {%- import 'zenos_ai/zenos_health.jinja' as HEALTH -%}
             {% set slots = HEALTH.slots_all() | from_json() %}
             {% set slot_to_label = HEALTH.slot_to_label() | from_json() %}
             {% set all_cabs = label_entities('Zen Cabinet' | slugify) | list %}
@@ -89,7 +89,7 @@ template:
           # MISSING REQUIRED CABINETS (LABEL OR ASSIGNMENT)
           #####################################################################
           missing_cabinets: >-
-            {%- import 'zenos/zenos_health.jinja' as HEALTH -%}
+            {%- import 'zenos_ai/zenos_health.jinja' as HEALTH -%}
             {% set required = HEALTH.slots_required() %}
             {% set slot_to_label = HEALTH.slot_to_label() | from_json() %}
             
@@ -113,7 +113,7 @@ template:
           # INVALID MULTIPLES (REQUIRED ONLY)
           #####################################################################
           invalid_multiples: >-
-            {%- import 'zenos/zenos_health.jinja' as HEALTH -%}
+            {%- import 'zenos_ai/zenos_health.jinja' as HEALTH -%}
             {% set required = HEALTH.slots_required() %}
             {% set slot_to_label = HEALTH.slot_to_label() | from_json() %}
 
@@ -135,7 +135,7 @@ template:
           # SLOT ENTITIES (FULL MAP)
           #####################################################################
           slot_entities: >-
-            {%- import 'zenos/zenos_health.jinja' as HEALTH -%}
+            {%- import 'zenos_ai/zenos_health.jinja' as HEALTH -%}
             {% set slots = HEALTH.slots_all() | from_json() %}
             {% set slot_to_label = HEALTH.slot_to_label() | from_json() %}
             {% set all_cabs = label_entities('Zen Cabinet' | slugify) | list %}
@@ -153,7 +153,7 @@ template:
           # RESOLVER SUGGESTIONS (BY SLOT)
           #####################################################################
           resolver_suggestions: >-
-            {%- import 'zenos/zenos_health.jinja' as HEALTH -%}
+            {%- import 'zenos_ai/zenos_health.jinja' as HEALTH -%}
             {% set required      = HEALTH.slots_required() | from_json() %}
             {% set optional      = HEALTH.slots_optional() | from_json() %}
             {% set slot_to_label = HEALTH.slot_to_label() | from_json() %}
@@ -190,14 +190,14 @@ template:
           # SLOT → LABEL MAPPING (single source of truth for Flynn)
           #####################################################################
           slot_to_label: >
-            {%- import 'zenos/zenos_health.jinja' as HEALTH -%}
+            {%- import 'zenos_ai/zenos_health.jinja' as HEALTH -%}
             {{- HEALTH.slot_to_label() | from_json({}) -}}
 
           #####################################################################
           # SLOT → DEFAULT ENTITY (canonical package entity IDs for Flynn)
           #####################################################################
           slot_to_default_entity: >
-            {%- import 'zenos/zenos_health.jinja' as HEALTH -%}
+            {%- import 'zenos_ai/zenos_health.jinja' as HEALTH -%}
             {{- HEALTH.slot_to_default_entity() | from_json({}) -}}
 
           timestamp: "{{ now().isoformat() }}"

--- a/packages/zenos_ai/sensors/zenos_cabinet_health.yaml
+++ b/packages/zenos_ai/sensors/zenos_cabinet_health.yaml
@@ -26,7 +26,7 @@ template:
         #######################################################################
         state: >
           {%- import 'zenos_ai/zenos_health.jinja' as HEALTH -%}
-          {{- HEALTH.zen_cabinet_health_state() -}}
+          {{- HEALTH.zen_cabinet_health_state() | from_json() -}}
           
 
         #######################################################################
@@ -90,7 +90,7 @@ template:
           #####################################################################
           missing_cabinets: >-
             {%- import 'zenos_ai/zenos_health.jinja' as HEALTH -%}
-            {% set required = HEALTH.slots_required() %}
+            {% set required = HEALTH.slots_required() | from_json() %}
             {% set slot_to_label = HEALTH.slot_to_label() | from_json() %}
             
             {% set parent_slug = 'Zen Cabinet' | slugify %}
@@ -114,7 +114,7 @@ template:
           #####################################################################
           invalid_multiples: >-
             {%- import 'zenos_ai/zenos_health.jinja' as HEALTH -%}
-            {% set required = HEALTH.slots_required() %}
+            {% set required = HEALTH.slots_required() | from_json() %}
             {% set slot_to_label = HEALTH.slot_to_label() | from_json() %}
 
             {% set parent_slug = 'Zen Cabinet' | slugify %}

--- a/packages/zenos_ai/sensors/zenos_label_health.yaml
+++ b/packages/zenos_ai/sensors/zenos_label_health.yaml
@@ -25,204 +25,43 @@ template:
         #######################################################################
         # STATE
         #######################################################################
-        state: >-
-          {% set required = [
-            'Zen Cabinet',
-            'Zen System Cabinet',
-            'Zen Dojo Cabinet',
-            'Zen Kata Cabinet',
-            'Zen Default Household',
-            'Zen Default Household Cabinet',
-            'Zen Default Family',
-            'Zen Default Family Cabinet',
-            'Zen Default User Cabinet',
-            'Zen Default AI User Cabinet',
-            'Zen History Cabinet',
-            'Zen Index Cabinet'
-          ] %}
-          {# Optional (not health-gated):
-             Instance: Zen Household, Zen Family, Zen User, Zen AI User
-             Instance cabinets: Zen User Cabinet, Zen AI User Cabinet
-             System: Zen Squirrel, Zen Fusion, Zen Health #}
-
-          {% set required_ids = required | map('slugify') | list %}
-          {% set label_index = labels() %}
-
-          {% set ns = namespace(
-              missing = [],
-              unassigned = [],
-              unhealthy = []
-          ) %}
-
-          {% for lid in required_ids %}
-
-            {# ----------------------------- #}
-            {# 1. Missing label entirely     #}
-            {# ----------------------------- #}
-            {% if lid not in label_index %}
-              {% set ns.missing = ns.missing + [lid] %}
-            {% else %}
-              {% set ents = label_entities(lid) or [] %}
-
-              {# -------------------------------- #}
-              {# 2. Unassigned: exists, 0 entities #}
-              {# -------------------------------- #}
-              {% if ents | count == 0 %}
-                {% set ns.unassigned = ns.unassigned + [lid] %}
-              {% else %}
-
-                {# ---------------------------------------- #}
-                {# 3. Unhealthy: one or more ents unavailable #}
-                {# ---------------------------------------- #}
-                {% set bad = ents
-                    | selectattr('state','in',['unavailable', 'unknown'])
-                    | list %}
-                {% if bad | count > 0 %}
-                  {% set ns.unhealthy = ns.unhealthy + [lid] %}
-                {% endif %}
-
-              {% endif %}
-            {% endif %}
-
-          {% endfor %}
-
-          {# ----------------------------- #}
-          {# PRIORITY: missing > unhealthy > unassigned > ok #}
-          {# ----------------------------- #}
-
-          {% if ns.missing | count > 0 %}
-            critical
-          {% elif ns.unhealthy | count > 0 %}
-            error
-          {% elif ns.unassigned | count > 0 %}
-            warn
-          {% else %}
-            ok
-          {% endif %}
+        state: >
+          {%- import 'zenos/zenos_health.jinja' as HEALTH -%}
+          {{ HEALTH.zen_label_health_state() }}
 
         #######################################################################
         # ATTRIBUTES
         #######################################################################
         attributes:
 
-          required_labels: >-
-            Zen Cabinet, Zen System Cabinet, Zen Dojo Cabinet, Zen Kata Cabinet,
-            Zen Default Household, Zen Default Household Cabinet,
-            Zen Default Family, Zen Default Family Cabinet,
-            Zen Default User Cabinet, Zen Default AI User Cabinet,
-            Zen History Cabinet, Zen Index Cabinet
+          # ALWAYS stored as a list, not CSV
+          required_labels: >
+              {%- import 'zenos/zenos_health.jinja' as HEALTH -%}
+              {{- HEALTH.required_labels() | from_json([]) -}}
 
-          existing_label_ids: >-
-            {% set required = [
-              'Zen Cabinet','Zen System Cabinet','Zen Dojo Cabinet','Zen Kata Cabinet',
-              'Zen Default Household','Zen Default Household Cabinet',
-              'Zen Default Family','Zen Default Family Cabinet',
-              'Zen Default User Cabinet','Zen Default AI User Cabinet',
-              'Zen History Cabinet','Zen Index Cabinet'
-            ] %}
-            {% set required_ids = required | map('slugify') | list %}
-            {% set label_index = labels() %}
-            {% set ns = namespace(ex=[]) %}
-            {% for lid in required_ids %}
-              {% if lid in label_index %}
-                {% set ns.ex = ns.ex + [lid] %}
-              {% endif %}
-            {% endfor %}
-            {{ ns.ex | join(', ') if ns.ex else 'none' }}
+          # ALWAYS stored as a list, not CSV
+          existing_label_ids: >
+            {%- import 'zenos/zenos_health.jinja' as HEALTH -%}
+            {{- HEALTH.existing_label_ids() | from_json([]) -}}
 
-          missing_label_ids: >-
-            {% set required = [
-              'Zen Cabinet','Zen System Cabinet','Zen Dojo Cabinet','Zen Kata Cabinet',
-              'Zen Default Household','Zen Default Household Cabinet',
-              'Zen Default Family','Zen Default Family Cabinet',
-              'Zen Default User Cabinet','Zen Default AI User Cabinet',
-              'Zen History Cabinet','Zen Index Cabinet'
-            ] %}
-            {% set required_ids = required | map('slugify') | list %}
-            {% set label_index = labels() %}
-            {% set ns = namespace(miss=[]) %}
-            {% for lid in required_ids %}
-              {% if lid not in label_index %}
-                {% set ns.miss = ns.miss + [lid] %}
-              {% endif %}
-            {% endfor %}
-            {{ ns.miss | join(', ') if ns.miss else 'none' }}
+          missing_label_ids: >
+            {%- import 'zenos/zenos_health.jinja' as HEALTH -%}
+            {{- HEALTH.missing_label_ids() | from_json([]) -}}
 
           #######################################################################
           # BROKEN / UNASSIGNED / UNHEALTHY LABEL IDS
           #######################################################################
 
-          unassigned_label_ids: >-
-            {% set required = [
-              'Zen Cabinet','Zen System Cabinet','Zen Dojo Cabinet','Zen Kata Cabinet',
-              'Zen Default Household','Zen Default Household Cabinet',
-              'Zen Default Family','Zen Default Family Cabinet',
-              'Zen Default User Cabinet','Zen Default AI User Cabinet',
-              'Zen History Cabinet','Zen Index Cabinet'
-            ] %}
-            {% set required_ids = required | map('slugify') | list %}
-            {% set label_index = labels() %}
-            {% set ns = namespace(unassigned=[]) %}
+          unassigned_label_ids: >
+            {%- import 'zenos/zenos_health.jinja' as HEALTH -%}
+            {{- HEALTH.unassigned_label_ids() | from_json([]) -}}
 
-            {% for lid in required_ids %}
-              {% if lid in label_index %}
-                {% set ents = label_entities(lid) or [] %}
-                {% if ents | count == 0 %}
-                  {% set ns.unassigned = ns.unassigned + [lid] %}
-                {% endif %}
-              {% endif %}
-            {% endfor %}
+          unhealthy_label_ids: >
+            {%- import 'zenos/zenos_health.jinja' as HEALTH -%}
+            {{- HEALTH.unhealthy_label_ids() | from_json([]) -}}
 
-            {{ ns.unassigned | join(', ') if ns.unassigned else 'none' }}
-
-          unhealthy_label_ids: >-
-            {% set required = [
-              'Zen Cabinet','Zen System Cabinet','Zen Dojo Cabinet','Zen Kata Cabinet',
-              'Zen Default Household','Zen Default Household Cabinet',
-              'Zen Default Family','Zen Default Family Cabinet',
-              'Zen Default User Cabinet','Zen Default AI User Cabinet',
-              'Zen History Cabinet','Zen Index Cabinet'
-            ] %}
-            {% set required_ids = required | map('slugify') | list %}
-            {% set label_index = labels() %}
-            {% set ns = namespace(unhealthy=[]) %}
-
-            {% for lid in required_ids %}
-              {% if lid in label_index %}
-                {% set ents = label_entities(lid) or [] %}
-                {% if ents | count > 0 %}
-                  {% set bad = ents | selectattr('state','in',['unknown','unavailable']) | list %}
-                  {% if bad | count > 0 %}
-                    {% set ns.unhealthy = ns.unhealthy + [lid] %}
-                  {% endif %}
-                {% endif %}
-              {% endif %}
-            {% endfor %}
-
-            {{ ns.unhealthy | join(', ') if ns.unhealthy else 'none' }}
-
-          healthy_label_ids: >-
-            {% set required = [
-              'Zen Cabinet','Zen System Cabinet','Zen Dojo Cabinet','Zen Kata Cabinet',
-              'Zen Default Household','Zen Default Household Cabinet',
-              'Zen Default Family','Zen Default Family Cabinet',
-              'Zen Default User Cabinet','Zen Default AI User Cabinet',
-              'Zen History Cabinet','Zen Index Cabinet'
-            ] %}
-            {% set required_ids = required | map('slugify') | list %}
-            {% set label_index = labels() %}
-            {% set ns = namespace(ok=[]) %}
-            {% for lid in required_ids %}
-              {% if lid in label_index %}
-                {% set ents = label_entities(lid) or [] %}
-                {% if ents | count > 0 %}
-                  {% set bad = ents | selectattr('state','in',['unavailable','unknown']) | list %}
-                  {% if bad | count == 0 %}
-                    {% set ns.ok = ns.ok + [lid] %}
-                  {% endif %}
-                {% endif %}
-              {% endif %}
-            {% endfor %}
-            {{ ns.ok | join(', ') if ns.ok else 'none' }}
+          healthy_label_ids: >
+            {%- import 'zenos/zenos_health.jinja' as HEALTH -%}
+            {{- HEALTH.healthy_label_ids() | from_json([]) -}}
 
           timestamp: "{{ now().isoformat() }}"

--- a/packages/zenos_ai/sensors/zenos_label_health.yaml
+++ b/packages/zenos_ai/sensors/zenos_label_health.yaml
@@ -16,6 +16,12 @@
 ###############################################################################
 
 template:
+  # Force periodic re-check as no longer listening to any entity
+ # @todo - we could use a flynn script state here (last_triggered) to ease off a bit
+  - trigger:
+      - trigger: time_pattern
+        minutes: /1
+
   - sensor:
       - name: Zen Label Health
         unique_id: zen_label_health
@@ -64,4 +70,5 @@ template:
             {%- import 'zenos_ai/zenos_health.jinja' as HEALTH -%}
             {{- HEALTH.healthy_label_ids() | from_json([]) -}}
 
-          timestamp: "{{ now().isoformat() }}"
+          # Removed this makes it way to chatty and triggers far too many script runs
+          # timestamp: "{{ now().isoformat() }}"

--- a/packages/zenos_ai/sensors/zenos_label_health.yaml
+++ b/packages/zenos_ai/sensors/zenos_label_health.yaml
@@ -27,7 +27,7 @@ template:
         #######################################################################
         state: >
           {%- import 'zenos_ai/zenos_health.jinja' as HEALTH -%}
-          {{ HEALTH.zen_label_health_state() | from_json() }}
+          {{ HEALTH.zen_label_health_state() }}
 
         #######################################################################
         # ATTRIBUTES

--- a/packages/zenos_ai/sensors/zenos_label_health.yaml
+++ b/packages/zenos_ai/sensors/zenos_label_health.yaml
@@ -26,7 +26,7 @@ template:
         # STATE
         #######################################################################
         state: >
-          {%- import 'zenos/zenos_health.jinja' as HEALTH -%}
+          {%- import 'zenos_ai/zenos_health.jinja' as HEALTH -%}
           {{ HEALTH.zen_label_health_state() }}
 
         #######################################################################
@@ -36,16 +36,16 @@ template:
 
           # ALWAYS stored as a list, not CSV
           required_labels: >
-              {%- import 'zenos/zenos_health.jinja' as HEALTH -%}
+              {%- import 'zenos_ai/zenos_health.jinja' as HEALTH -%}
               {{- HEALTH.required_labels() | from_json([]) -}}
 
           # ALWAYS stored as a list, not CSV
           existing_label_ids: >
-            {%- import 'zenos/zenos_health.jinja' as HEALTH -%}
+            {%- import 'zenos_ai/zenos_health.jinja' as HEALTH -%}
             {{- HEALTH.existing_label_ids() | from_json([]) -}}
 
           missing_label_ids: >
-            {%- import 'zenos/zenos_health.jinja' as HEALTH -%}
+            {%- import 'zenos_ai/zenos_health.jinja' as HEALTH -%}
             {{- HEALTH.missing_label_ids() | from_json([]) -}}
 
           #######################################################################
@@ -53,15 +53,15 @@ template:
           #######################################################################
 
           unassigned_label_ids: >
-            {%- import 'zenos/zenos_health.jinja' as HEALTH -%}
+            {%- import 'zenos_ai/zenos_health.jinja' as HEALTH -%}
             {{- HEALTH.unassigned_label_ids() | from_json([]) -}}
 
           unhealthy_label_ids: >
-            {%- import 'zenos/zenos_health.jinja' as HEALTH -%}
+            {%- import 'zenos_ai/zenos_health.jinja' as HEALTH -%}
             {{- HEALTH.unhealthy_label_ids() | from_json([]) -}}
 
           healthy_label_ids: >
-            {%- import 'zenos/zenos_health.jinja' as HEALTH -%}
+            {%- import 'zenos_ai/zenos_health.jinja' as HEALTH -%}
             {{- HEALTH.healthy_label_ids() | from_json([]) -}}
 
           timestamp: "{{ now().isoformat() }}"

--- a/packages/zenos_ai/sensors/zenos_label_health.yaml
+++ b/packages/zenos_ai/sensors/zenos_label_health.yaml
@@ -27,7 +27,7 @@ template:
         #######################################################################
         state: >
           {%- import 'zenos_ai/zenos_health.jinja' as HEALTH -%}
-          {{ HEALTH.zen_label_health_state() }}
+          {{ HEALTH.zen_label_health_state() | from_json() }}
 
         #######################################################################
         # ATTRIBUTES


### PR DESCRIPTION
2026-03-12-slots-labels-source-of-truth
Introducing: zenos_health.jinja

- Massive refactor to deduplicate cabinet slot, label and default entity data.

- Centralized, encapsulated source of truth for more simple maintenance.

Jinja refactored from:
- zenos_cabinet_health.yaml
- zenos_label_health.yaml
- flynn.yaml

Still some more to simplify in zenos_cabinet_health, but it can wait, and of course, in the future, those edits can be isolated from any restructuring in the package

@note - All jinja generated lists involved now return as lists, no more returning comma separated or the word 'none'
