### PR TITLE
2026-03-12-prevent-Flynn-Stepgate-Sentinel-over-triggering

### DIFF
--- a/packages/zenos_ai/flynn.yaml
+++ b/packages/zenos_ai/flynn.yaml
@@ -67,8 +67,16 @@ automation:
         event: start
       - trigger: state
         entity_id: sensor.zen_label_health
+      # ---------------------------------------------------------
+      # Only trigger on state change of sensor.zen_cabinet_health(enum) - not on attributes
+      # ---------------------------------------------------------
       - trigger: state
         entity_id: sensor.zen_cabinet_health
+        to:
+        - critical
+        - error
+        - warn
+        - ok
       - trigger: state
         entity_id: sensor.zen_monastery_health
     conditions: []


### PR DESCRIPTION
"Flynn: Stepgate Sentinel" is triggering on state change of "Zen Cabinet Health" and filling my logs :)

Zen Cabinet Health has not changed in 13 hours...

"Flynn: Stepgate Sentinel" running every minute on that trigger...

```YAML
# ---------------------------------------------------------
# Only trigger on state change of sensor.zen_cabinet_health(enum) - not on attributes
# ---------------------------------------------------------
- trigger: state
  entity_id: sensor.zen_cabinet_health
  to:
  - critical
  - error
  - warn
  - ok