### PR TITLE
feat: Inspect device_block + output_fields, Index drawer blurbs via FileCabinet (4.2.1)

### DIFF
--- a/packages/zenos_ai/dojotools/dojotools_index.yaml
+++ b/packages/zenos_ai/dojotools/dojotools_index.yaml
@@ -1,6 +1,6 @@
 ###############################################################################
 # ZenOS-AI DojoTools: Index Cluster
-# Version: 4.0.0 RC2
+# Version: 4.2.1
 #
 # Scripts:
 #   zen_dojotools_query   — ZQ-1 entity filter/query engine
@@ -24,7 +24,7 @@ script:
 
   zen_dojotools_query:
     alias: Zen DojoTools Query
-    description: "Zen DojoTools Query “ZQ-1” (4.0.0 RC2)\nQuery is a deterministic entity
+    description: "Zen DojoTools Query “ZQ-1” (4.2.1)\nQuery is a deterministic entity
       selector. It takes a starting list of entity_ids (or an empty/null list) and runs
       them through a series of filters—domain, labels, areas, device_id, device_class,
       states, numeric ranges, regex, and semantic shortcuts. Each filter narrows the
@@ -90,7 +90,7 @@ script:
         sequence:
         - variables:
             help_json: "{{\n  {\n    \"tool\": \"Zen DojoTools Query (ZQ-1)\",\n    \"version\":
-              \"4.0.0 RC2\",\n    \"overview\":\n      \"ZQ-1 is a deterministic, multi-stage
+              \"4.2.1\",\n    \"overview\":\n      \"ZQ-1 is a deterministic, multi-stage
               entity filtering engine designed for Home Assistant. It consumes flexible
               JSON filter definitions and produces a fully evaluated list of entity_ids.
               Every filter acts conjunctively (logical AND), meaning each stage narrows
@@ -437,7 +437,7 @@ script:
       response_variable: inspect_result
     alias: Zen DojoTOOLS Inspect
     mode: parallel
-    description: Inspect (4.0.0 RC2). Deep dive on one or more entities. Attributes
+    description: Inspect (4.2.1). Deep dive on one or more entities. Attributes
       are key-scanned for safety. Cabinet sensors expose header metadata only; use cabinet
       tools for full volume access.
     fields:
@@ -507,7 +507,7 @@ script:
         - variables:
             query_help: '{{ zen_query_help | default({}) | tojson }}'
             help_json: "{{\n  {\n    \"tool\": \"Zen DojoTools Index\",\n    \"version\":
-              \"4.0.0 RC2\",\n    \"intent\": \"High-resolution reasoning. Convert
+              \"4.2.1\",\n    \"intent\": \"High-resolution reasoning. Convert
               arbitrary entity + label sets into a unified hypergraph suitable for fusion,
               summarization, planning, and contextual inference.\",\n    \"you_should_use_this_tool_when\":
               [\n      \"You need to combine labels, entities, or both into a logical
@@ -807,7 +807,7 @@ script:
     - stop: Zen DojoTools Index Complete
       response_variable: label_entity_logic_result
     alias: Zen DojoTools Index
-    description: 'Zen DojoTools (Hyper)Index (4.0.0 RC2). Universal HyperGraph Index
+    description: 'Zen DojoTools (Hyper)Index (4.2.1). Universal HyperGraph Index
       for entity and label reasoning.
   
       Merges labels, entities, drawers, and metadata into a unified, deterministic result
@@ -936,7 +936,7 @@ automation:
 
   - id: '1749771199185'
     alias: DojoTools Zen Index Event Handler
-    description: 'Event Listener (4.0.0 RC2) to recurse index calls.  REQUIRES DojoTOOLS
+    description: 'Event Listener (4.2.1) to recurse index calls.  REQUIRES DojoTOOLS
       Zen Index (2.0.0 or greater)
   
       '


### PR DESCRIPTION
Closes #7

## Summary

- **Inspect**: `device_block` (always when device exists — id, name, manufacturer, model, area_id, integration), `device_tree` (extended=true — via_device_id, parent, siblings, config_entries), `output_fields` param for field selection (defaults on: timestamps, device, volume; opt-in: +attributes, +statistics; suppress: -timestamps/-device/-volume), `label_targets` param for drawer blurb reads
- **Index**: `output_fields` passed through to Inspect when expand_entities=true; `label_targets` from label_1/label_2 passed to Inspect; drawer blurbs now properly populated in `result.drawers` via FileCabinet label read inside Inspect (was dead code — always returned key names, never content)
- **Query**: `output_fields` stub declared (no-op, reserved)
- All tools bumped to **4.2.1** (Scheduler 4.1.0 floor)

## Bug fixes (all found in UAT by Nyx)

| Bug | Fix |
|---|---|
| `\| split` not a valid HA Jinja filter in `output_fields_input` | `\| regex_findall('[^,]+')` |
| `state_attr(entity, 'device_id')` always None — registry field, not state attr | `device_id(entity_id)` |
| `device_attr(dev_id, 'identifiers')` returns a set — not JSON serializable | `\| list` |
| `device_attr(dev_id, 'config_entries')` returns a set | `\| list` |
| `label_targets_input` had same `\| split` pattern as Bug 1 | `\| regex_findall('[^,]+')` |

## Architecture notes

- Inspect is the HA domain reader. When `label_targets` are present it calls FileCabinet internally (after entity loop, one call) and emits `drawers: {key: blurb}` in its response. Index never calls FileCabinet directly.
- `volume` field suppressed on non-cabinet entities — `{is_cabinet: false}` was appearing on every entity in a 187-entity expand.
- `output_fields_input` and `_show_*` flags hoisted to Inspect init block — computed once per call, not once per entity.

## UAT

Full matrix passed on live H:\ by Nyx (2026-03-15):
- All 5 bugs confirmed fixed
- device_block populated correctly
- ZQ-1 filter (strict=true) ✓
- Index → Inspect drawer blurbs ✓
- Direct Inspect drawer blurbs ✓
- Hypergraph mode (cross-domain) ✓
- Full pipeline: Index (kung_fu OR zen_health, hypergraph) → 30 nodes, 40 edges ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)