### PR TITLE
2026-03-21-str object-has-no-attribute-entity_id

### DIFF
--- a/packages/zenos_ai/sensors/zenos_cabinet_health.yaml
+++ b/packages/zenos_ai/sensors/zenos_cabinet_health.yaml
@@ -206,7 +206,7 @@ template:
               {%- if ents | count == 0 -%}
                 {%- set ns.m = ns.m | combine({ slot: 'absent' }) -%}
               {%- else -%}
-                {%- set eid = (ents | first).entity_id -%}
+                {%- set eid = (ents | first) -%}
                 {%- set _v = state_attr(eid, 'variables') -%}
                 {%- set cab_state = 'online' if (_v is mapping and 'AI_Cabinet_VolumeInfo' in _v) else 'init' -%}
                 {%- set ns.m = ns.m | combine({ slot: cab_state }) -%}


### PR DESCRIPTION
The entities are already strings - the new code from yesterday assumed expanded/state objects

Address:
Template variable error: 'str object' has no attribute '**entity_id**' when rendering '{%- import 'zenos_ai/zenos_health.jinja' as HEALTH -%} {%- set slots = HEALTH.slots_all() | from_json() -%} {%- set slot_to_label = HEALTH.slot_to_label() | from_json() -%} {%- set all_cabs = label_entities('Zen Cabinet' | slugify) | list -%} {%- set ns = namespace(m={}) -%} {%- for slot in slots -%} {%- set label_slug = slot_to_label[slot] | slugify -%} {%- set ents = intersect(all_cabs, label_entities(label_slug) or []) | list -%} {%- if ents | count == 0 -%} {%- set ns.m = ns.m | combine({ slot: 'absent' }) -%} {%- else -%} {%- set eid = (ents | first).**entity_id** -%} {%- set _v = state_attr(eid, 'variables') -%} {%- set cab_state = 'online' if (_v is mapping and 'AI_Cabinet_VolumeInfo' in _v) else 'init' -%} {%- set ns.m = ns.m | combine({ slot: cab_state }) -%} {%- endif -%} {%- endfor -%} {{ ns.m | tojson }}'