### PR TITLE
2026-03-22-flynn_system_ready-template-loop

### DIFF
--- a/packages/zenos_ai/sensors/zenos_system_health.yaml
+++ b/packages/zenos_ai/sensors/zenos_system_health.yaml
@@ -83,4 +83,4 @@ template:
           {{ states('sensor.zen_label_health') == 'ok'
              and states('sensor.zen_cabinet_health') == 'ok'
              and states('sensor.zen_monastery_health') in ['ok', 'warn'] }}
-        icon: "{{ 'mdi:check-circle' if this.state == 'on' else 'mdi:alert-circle' }}"
+        icon: "{{ 'mdi:check-circle' if is_state('binary_sensor.flynn_system_ready', 'on') else 'mdi:alert-circle' }}"


### PR DESCRIPTION
Fix:

Template loop detected while processing event: <Event state_changed[L]: entity_id=binary_sensor.flynn_system_ready, old_state=<state binary_sensor.flynn_system_ready=off; icon=mdi:check-circle, friendly_name=Flynn System Ready @ 2026-03-22T13:40:25.034781-07:00>, new_state=<state binary_sensor.flynn_system_ready=on; icon=mdi:alert-circle, friendly_name=Flynn System Ready @ 2026-03-22T13:40:25.036452-07:00>>, skipping template render for Template[{{ 'mdi:check-circle' if this.state == 'on' else 'mdi:alert-circle' }}]

@see Issue and alternative approach using a trigger: https://github.com/home-assistant/core/issues/58056