### PR TITLE
2026-03-27-Reserved-Word-Parameter-label_description

### DIFF
--- a/packages/zenos_ai/dojotools/dojotools_scribe.yaml
+++ b/packages/zenos_ai/dojotools/dojotools_scribe.yaml
@@ -178,7 +178,7 @@ script:
         selector:
           text:
 
-      label_description:
+      label_description_generic:
         name: Label Description
         description: generic collection description
         required: false
@@ -278,7 +278,8 @@ script:
         required: false
         selector:
           entity:
-            domain: person
+            filter:
+              domain: person
 
       what_it_does:
         name: What It Does
@@ -519,7 +520,7 @@ script:
       # -------------------------------------------------------------------
       - variables:
           _label_desc: >-
-            {% set d = label_description | default('', true) | string | trim %}
+            {% set d = label_description_generic | default('', true) | string | trim %}
             {% if d != '' %}
               {{ d }}
             {% elif _base_label != '' %}
@@ -856,6 +857,7 @@ script:
                       action_type: create
                       label_list:
                         - "{{ _base_label }}"
+                      #new_description: "{{ _label_desc }}"
                       new_description: "{{ _label_desc }}"
                       confirm: true
                       caller_token: "{{ caller_token }}"

--- a/packages/zenos_ai/dojotools/dojotools_scribe.yaml
+++ b/packages/zenos_ai/dojotools/dojotools_scribe.yaml
@@ -1390,7 +1390,7 @@ script:
                     {% set base = _k2 if _k2 is mapping else {} %}
                     {{
                       {
-                        "version": base.get('version', version | default('1.0.0')),
+                        "version": base.get('version', version_semantic | default('1.0.0')),
                         "friendly_name": base.get('friendly_name', friendly_name | default(_slug)),
                         "label": base.get('label', _base_label),
                         "primary_index_key": base.get('primary_index_key', _primary_index_key),

--- a/packages/zenos_ai/dojotools/dojotools_scribe.yaml
+++ b/packages/zenos_ai/dojotools/dojotools_scribe.yaml
@@ -346,7 +346,7 @@ script:
         selector:
           boolean:
 
-      version:
+      version_semantic:
         name: Version
         description: semantic version string
         required: false
@@ -857,7 +857,6 @@ script:
                       action_type: create
                       label_list:
                         - "{{ _base_label }}"
-                      #new_description: "{{ _label_desc }}"
                       new_description: "{{ _label_desc }}"
                       confirm: true
                       caller_token: "{{ caller_token }}"
@@ -886,7 +885,7 @@ script:
                         "artifact_class": "thought",
                         "artifact_state": "draft",
                         "schema_version": "1.0.0",
-                        "version": version | default('1.0.0'),
+                        "version": version_semantic | default('1.0.0'),
                         "friendly_name": friendly_name | default(_slug),
                         "key": _primary_index_key,
                         "primary_index_key": _primary_index_key,


### PR DESCRIPTION
Fix: zen_dojotools_scribe
Error: TypeError: Object of type function is not JSON serializable

Fixes https://github.com/nathan-curtis/zenos-ai/issues/114

Fixes legacy syntax for person selector
```
        selector:
          entity:
            filter:
              domain: person
```