### PR TITLE
Feat/ectoplasm apply cabinet macros

### DIFF
--- a/custom_templates/zenos_ai/zen_os_1.jinja
+++ b/custom_templates/zenos_ai/zen_os_1.jinja
@@ -339,6 +339,7 @@
   {%- set candidate = raw -%}
 
   {# unwrap FileCabinet value wrapper once #}
+  {# @todo - resolve_zenai_essence(raw) should only every be passed a 'value' unwrapped by CABS.cabinet_drawer_value()  #}
   {%- if candidate is mapping
         and 'value' in candidate
         and candidate.value is mapping -%}

--- a/custom_templates/zenos_ai/zen_os_1.jinja
+++ b/custom_templates/zenos_ai/zen_os_1.jinja
@@ -185,6 +185,7 @@
      ============================================================ #}
   {%- for cab in sensor_cabs -%}
 
+    {#-
     {%- set raw_vars = state_attr(cab, 'variables') -%}
     {%- set vars = raw_vars if raw_vars is mapping else {} -%}
 
@@ -196,6 +197,9 @@
           and candidate.value is mapping -%}
       {%- set candidate = candidate.value -%}
     {%- endif -%}
+    -#}
+    {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
+    {%- set candidate = CABS.cabinet_drawer_value(cab, 'zenai_essence') | from_json() -%}
 
     {%- if candidate is mapping and (
           candidate.get('identity') is mapping
@@ -259,10 +263,14 @@
     {# ---- Stage -1: person.* owner ACL ---- #}
     {%- if raw | lower | regex_search('^person\\.') -%}
       {%- for cab in pool if ns.result is none -%}
+        {#
         {%- set raw_vars = state_attr(cab.entity_id, 'variables') -%}
         {%- set volinfo = raw_vars if raw_vars is mapping else {} -%}
         {%- set vol_ACI = volinfo.get('AI_Cabinet_VolumeInfo', {}) -%}
         {%- set vol_ACI_value = vol_ACI.get('value', {}) if vol_ACI is mapping else {} -%}
+        #}
+        {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
+        {%- set vol_ACI_value = CABS.cabinet_drawer_value(cab.entity_id, 'AI_Cabinet_VolumeInfo') | from_json() -%}
         {%- set acls = vol_ACI_value.get('acls', {}) if vol_ACI_value is mapping else {} -%}
         {%- set owner = acls.get('owner') -%}
 
@@ -421,6 +429,7 @@
   {%- set vol_acls = {} -%}
   {%- if ns.result is none -%}
       {%- set cab_entity = cab.get('entity_id') -%}
+      {#-
       {%- set raw_vars = state_attr(cab_entity, 'variables') -%}
       {%- set volinfo_root = raw_vars if raw_vars is mapping else {} -%}
       {%- set vol_ACI = volinfo_root.get('AI_Cabinet_VolumeInfo', {}) -%}
@@ -431,6 +440,10 @@
       {%- if not (vol_ACI_value is mapping) -%}
         {%- set vol_ACI_value = {} -%}
       {%- endif -%}
+      -#}
+      {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
+      {%- set vol_ACI_value = CABS.cabinet_drawer_value(cab_entity, 'AI_Cabinet_VolumeInfo') | from_json() -%}
+
       {%- set vol_acls = vol_ACI_value.get('acls', {}) -%}
   {%- endif -%}
 
@@ -624,6 +637,13 @@
 
     {%- if ai_user_candidates | length > 0 -%}
       {%- set preferred_entity = ai_user_candidates | first -%}
+      {#-
+      @todo - Nathan - not sure if you want the drawer or the drawer value here - looks like the drawer - but cabnnot imaging why
+      @todo - Nathan - you should assign `zenai_essence_drawer` or `zenai_essence_drawer_value` to cab.essence
+      -#}
+      {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
+      {%- set zenai_essence_drawer = CABS.cabinet_drawer(preferred_entity, 'zenai_essence', {}) | from_json() -%}
+      {%- set zenai_essence_drawer_value = CABS.cabinet_drawer_value(preferred_entity, 'zenai_essence', {}) | from_json() -%}
       {%- set cab = {
         "entity_id": preferred_entity,
         "name": state_attr(preferred_entity, 'friendly_name') | default(ai_user, true),
@@ -732,6 +752,13 @@
         if essence_raw is string
         else essence_raw
   -%}
+  {#-
+  @todo - Nathan - not sure if you want the drawer or the drawer value here - looks like the drawer - but cabnnot imaging why
+  @todo - Nathan - you should assign `zenai_essence_drawer` or `zenai_essence_drawer_value` to cab.essence
+  -#}
+  {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
+  {%- set zenai_essence_drawer = CABS.cabinet_drawer(preferred_entity, 'zenai_essence', {}) | from_json() -%}
+  {%- set zenai_essence_drawer_value = CABS.cabinet_drawer_value(preferred_entity, 'zenai_essence', {}) | from_json() -%}
 
   {{ {
     "cabinet": cabinet_entity,
@@ -970,19 +997,23 @@
   {%- else %}
 
     {# Pull variables #}
+    {#-
     {%- set sys_vars = state_attr(sys_cab, 'variables') or {} %}
-
+    -#}
     {# Canonical drawer names #}
     {%- set drawer_purpose    = "purpose" -%}
     {%- set drawer_directives = "directives" -%}
     {%- set drawer_cortex     = "cortex" -%}
 
     {# Extract raw #}
+    {#-
     {%- set purpose_val    = sys_vars.get(drawer_purpose, "") %}
     {%- set directives_val = sys_vars.get(drawer_directives, "") %}
     {%- set cortex_val     = sys_vars.get(drawer_cortex, "") %}
+    -#}
 
     {# Unwrap value: wrapper #}
+    {#-
     {%- if purpose_val is mapping and 'value' in purpose_val %}
       {%- set purpose_val = purpose_val.value %}
     {%- endif %}
@@ -992,6 +1023,13 @@
     {%- if cortex_val is mapping and 'value' in cortex_val %}
       {%- set cortex_val = cortex_val.value %}
     {%- endif %}
+    -#}
+    {#- @todo - not that the following lines negate almost all lines above -#}
+    {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
+    {%- set purpose_val = CABS.cabinet_drawer_value(sys_cab, drawer_purpose, '') | from_json() -%}
+    {%- set directives_val = CABS.cabinet_drawer_value(sys_cab, drawer_directives, '') | from_json() -%}
+    {%- set cortex_val = CABS.cabinet_drawer_value(sys_cab, drawer_cortex, '') | from_json() -%}
+
 
     {# Store results #}
     {%- set ns.result = {
@@ -1066,6 +1104,7 @@
 {%- macro manifest_loader() -%}
   {%- set mani_cab = states('sensor.zen_default_household_cabinet_resolved') -%}
 
+  {#-
   {%- set manifest = {} -%}
 
   {%- if mani_cab -%}
@@ -1078,8 +1117,13 @@
       {%- set manifest = raw_mani -%}
     {%- endif -%}
   {%- endif -%}
+  -#}
 
-  {%- set result = dict(
+  {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
+  {%- set manifest = CABS.cabinet_drawer_value(mani_cab, 'zen_library_manifest') | from_json() -%}
+
+
+    {%- set result = dict(
     cabinet = mani_cab,
     manifest = manifest
   ) -%}
@@ -1102,11 +1146,15 @@
   {%- set hh_cab = states('sensor.zen_default_household_cabinet_resolved') -%}
   {%- set result = {'status': 'not_built', 'roster': {}, 'tree': {}} -%}
   {%- if hh_cab not in ['', 'unknown', 'unavailable'] -%}
+    {#-
     {%- set hh_vars  = state_attr(hh_cab, 'variables') | default({}, true) -%}
     {%- set hh_vars  = hh_vars if hh_vars is mapping else {} -%}
     {%- set raw_mani = hh_vars.get('zen_identity_manifest') | default({}, true) -%}
     {%- set mani     = raw_mani.get('value', raw_mani) if raw_mani is mapping and 'value' in raw_mani else raw_mani -%}
     {%- set mani     = mani if mani is mapping else {} -%}
+    -#}
+    {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
+    {%- set mani = CABS.cabinet_drawer_value(hh_cab, 'zen_identity_manifest') | from_json() -%}
     {%- if 'roster' in mani and 'tree' in mani -%}
       {#- v4.3+ shape: both roster and tree present -#}
       {%- set result = mani | combine({'status': 'ok'}) -%}
@@ -1129,6 +1177,7 @@
 #}
 {%- macro root_index() -%}
   {%- set hcab = states('sensor.zen_default_household_cabinet_resolved') -%}
+  {#-
   {%- set ci_entry = {} -%}
   {%- if hcab -%}
     {%- set hc_vars = state_attr(hcab, 'variables') or {} -%}
@@ -1137,6 +1186,10 @@
   {%- endif -%}
   {%- set ci_val = ci_entry.get('value') -%}
   {%- set ci_val = ci_val if ci_val is mapping else {} -%}
+  -#}
+  {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
+  {%- set ci_val = CABS.cabinet_drawer_value(hcab, '_compact_index') | from_json() -%}
+
   {%- set ci_generated = ci_val.get('generated', '') -%}
   {%- set ci_labels = ci_val.get('labels', []) -%}
   {%- if ci_generated | length > 0 -%}
@@ -1228,9 +1281,14 @@
 
   {# system-priority drawers: include urgency+attention micro-signal from kata only #}
   {%- if value['priority'] | default('') == 'system' -%}
-    {%- set kata_cab = states('sensor.zen_kata_cabinet_resolved') -%}
-    {%- set kata_node = (state_attr(kata_cab, 'variables') or {}).get(drawer, {}) -%}
-    {%- set kata_val = kata_node.get('value', kata_node) if kata_node is mapping else {} -%}
+      {%- set kata_cab = states('sensor.zen_kata_cabinet_resolved') -%}
+      {#-
+      {%- set kata_node = (state_attr(kata_cab, 'variables') or {}).get(drawer, {}) -%}
+      {%- set kata_val = kata_node.get('value', kata_node) if kata_node is mapping else {} -%}
+      -#}
+      {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
+      {%- set kata_val = CABS.cabinet_drawer_value(kata_cab, drawer) | from_json() -%}
+
     {%- set kata_signal = {
       'urgency': kata_val.get('urgency', 1),
       'attention': kata_val.get('attention', none)
@@ -1247,14 +1305,20 @@
   {% set dojo_cab = states('sensor.zen_dojo_cabinet_resolved') %}
   {% set kata_cab = states('sensor.zen_kata_cabinet_resolved') %}
   {% set dojo = state_attr(dojo_cab, 'variables') or {} %}
+  {#-
   {% set kata_vars = state_attr(kata_cab, 'variables') or {} %}
+  -#}
   {% set meta = (dojo_kungfu_meta(dojo) | default('{}')) | from_json %}
   {% set data = namespace(components=[]) %}
 
   {# get current zen_summary — flat schema (supersummary writes value directly) #}
+  {#-
   {% set zen_summary_root = kata_vars.get('zen_summary', {}) %}
   {% set zen_summary_val = zen_summary_root.get('value', zen_summary_root) %}
   {% set zen_summary = zen_summary_val if zen_summary_val is mapping else {} %}
+  -#}
+  {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
+  {%- set zen_summary = CABS.cabinet_drawer_value(kata_cab, 'zen_summary') | from_json() -%}
 
   {% for drawer, node in dojo.items() %}
     {% if drawer == 'kung_fu' %}
@@ -1579,6 +1643,7 @@
         {# ----------------------------------------------------
            2. Load AI Cabinet variables
            ---------------------------------------------------- #}
+        {#-
         {%- set cab_vars = state_attr(ib.get('cabinet'), 'variables') or {} -%}
         {%- set raw_ess = cab_vars.get('zenai_essence') -%}
         {%- if raw_ess is mapping and raw_ess.get('value') is mapping -%}
@@ -1588,6 +1653,11 @@
         {%- else -%}
           {%- set essence = {} -%}
         {%- endif -%}
+        -#}
+
+        {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
+        {%- set essence = CABS.cabinet_drawer_value(ai_cab, 'zenai_essence') | from_json() -%}
+
 
         {# Familiar — read from essence; companion (three-layer) maps to familiar #}
         {%- if essence.get('companion') is mapping -%}
@@ -1768,6 +1838,7 @@ Executing: ~WAKE~ <{{ now().isoformat() }}>
     {# ----------------------------------------------------
        2. Pull AutoContext from AI Cabinet
        ---------------------------------------------------- -#}
+    {#-
     {%- set auto_vars = state_attr(ai_cab, 'variables') or {} -%}
     {%- set prog = auto_vars.get('programs_auto_exec') -%}
     {%- if prog is mapping and 'value' in prog -%}
@@ -1775,7 +1846,9 @@ Executing: ~WAKE~ <{{ now().isoformat() }}>
     {%- else -%}
       {%- set auto_exec = none -%}
     {%- endif -%}
-
+    -#}
+    {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
+    {%- set auto_exec = CABS.cabinet_drawer_value(ai_cab, 'programs_auto_exec', none) | from_json() -%}
 AutoContext:
 {{ auto_exec | default("null") | tojson }}
 
@@ -1783,6 +1856,7 @@ AutoContext:
        3. Wake Scene Rendering (Essence Driven)
        Load essence from the persona's cabinet — works for any capsule.
        ---------------------------------------------------- -#}
+    {#-
     {%- set ai_cab_ent = ib.get('cabinet') -%}
     {%- set cab_vars = state_attr(ai_cab_ent, 'variables') or {} -%}
     {%- set raw_ess = cab_vars.get('zenai_essence') -%}
@@ -1793,6 +1867,8 @@ AutoContext:
     {%- else -%}
       {%- set essence = {} -%}
     {%- endif -%}
+    -#}
+    {%- set essence = CABS.cabinet_drawer_value(ai_cab, 'zenai_essence', none) | from_json() -%}
 
     {%- if essence -%}
       {{- render_wake_from_essence(essence) -}}

--- a/custom_templates/zenos_ai/zenos_cabinets.jinja
+++ b/custom_templates/zenos_ai/zenos_cabinets.jinja
@@ -145,6 +145,7 @@ Purpose: Retrieves the variables attribute from a specific sensor entity while p
 Input: entity_id (string): The full Home Assistant entity ID (e.g., sensor.kitchen_cabinet).
 Logic: Checks if the entity_id is provided and if the entity currently exists/has a valid state in the state machine using has_value().
        If the entity is valid, extracts the variables attribute with defensive fallback for any falsy result.
+       If the variables attribute exists but is not a mapping, returns defensive fallback.
 
 Fallback Behavior: The second parameter of | default(fallback, true) ensures that not only missing attributes,
        but also null, false, empty strings, empty lists, and empty dicts are replaced with the fallback value.
@@ -157,6 +158,9 @@ Technical Note: By using to_json(pretty_print=true), the output is optimized for
     {%- set rv = fallback -%}
     {%- if entity_id and has_value(entity_id) -%}
         {%- set rv = state_attr(entity_id, 'variables') | default(fallback, true) -%}
+    {%- endif -%}
+    {%- if not rv is mapping -%}
+        {%- set rv = fallback -%}
     {%- endif -%}
     {{- rv | to_json(pretty_print=true) -}}
 {%- endmacro -%}

--- a/custom_templates/zenos_ai/zenos_cabinets.jinja
+++ b/custom_templates/zenos_ai/zenos_cabinets.jinja
@@ -306,3 +306,356 @@ Output: A JSON-formatted string of the drawer (or fallback if not found).
     {{- drawer | to_json(pretty_print=true) -}}
 {%- endmacro -%}
 
+
+
+{#-
+@macro: volume_drawer_value
+@desc: Extracts the 'value' field from a named drawer in a volume object.
+@param: volume (dict) - The volume dictionary to access.
+@param: drawer_key (string) - The key name of the drawer to access.
+@param: fallback (any) - Value to return if 'value' field is not found. Defaults to {}.
+@returns: JSON Object/String - The 'value' field from the drawer, or fallback if not found.
+@note: Handles both JSON-encoded string values at the drawer level and within the 'value' field.
+@note: Parallels cabinet_drawer_value() but operates on a volume dict rather than an entity ID.
+@usage: {{ volume_drawer_value(my_volume, 'metadata') | from_json() }}
+        {{ volume_drawer_value(my_volume, 'config', {}) | from_json() }}
+
+"Volume Drawer Value Extractor" for accessing the 'value' field from a drawer within a volume.
+Purpose: Simplifies access to the data payload stored in volume attributes that follow the {value, timestamp} structure.
+Input: volume (dict): The volume object.
+       drawer_key (string): The name of the drawer containing the value.
+       fallback (any): Default if the value field doesn't exist.
+Logic: Retrieves the drawer from the volume dict.
+       Extracts the 'value' field from the drawer.
+       Handles JSON-encoded strings within the value field.
+Output: A JSON-formatted string of the value (or fallback if missing).
+-#}
+{%- macro volume_drawer_value(volume, drawer_key, fallback={}) -%}
+    {%- set drawer = volume.get(drawer_key, {}) -%}
+    {%- set value = drawer.get('value', fallback) -%}
+    {#- Note that in some cabinets, the data under 'drawer_key'->'value' might be a JSON encoded string -#}
+    {%- if value is string -%}
+        {%- set value = value | from_json(fallback) -%}
+    {%- endif -%}
+    {{- value | to_json(pretty_print=true) -}}
+{%- endmacro -%}
+
+{#-
+@macro: volume_guid
+@desc: Extracts the GUID identifier from a volume object's VolumeInfo metadata.
+@param: volume (dict) - The volume dictionary containing VolumeInfo metadata.
+@param: fallback (string) - Value to return if GUID is not found. Defaults to ''.
+@returns: String - The GUID/ID value from VolumeInfo, or fallback if not found.
+@note: Assumes the volume follows the standard cabinet schema with 'AI_Cabinet_VolumeInfo' drawer.
+@note: Safely handles missing VolumeInfo by returning fallback; does not output JSON.
+@usage: {{ volume_guid(my_volume) }}
+        {{ volume_guid(my_volume, 'unknown') }}
+
+"Volume GUID Extractor" for retrieving the unique identifier from a volume's metadata block.
+Purpose: Provides direct access to a volume's identity (GUID/ID) from its VolumeInfo metadata without manual traversal.
+Input: volume (dict): The volume object.
+       fallback (string): Default if the ID/GUID is not present.
+Logic: Fetches the VolumeInfo drawer from the volume using volume_drawer_value().
+       Extracts the 'id' field from the VolumeInfo metadata.
+       Safely handles missing or null values, returning fallback.
+Output: A plain string GUID (not JSON-encoded), trimmed of whitespace.
+-#}
+{%- macro volume_guid(volume, fallback='') -%}
+    {%- set _vi_val = volume_drawer_value(volume, 'AI_Cabinet_VolumeInfo') | from_json() -%}
+    {%- set _guid = _vi_val.get('id', fallback) | string | trim -%}
+    {{- _guid -}}
+{%- endmacro -%}
+
+
+{#- </editor-fold> -#}
+
+{#- <editor-fold desc="AI_Cabinet_VolumeInfo" defaultstate="collapsed"> -#}
+
+{#-
+@macro: cabinet_volume_info
+@desc: Retrieves the 'AI_Cabinet_VolumeInfo' metadata block from a cabinet sensor.
+@param: entity_id (string) - The full HA entity ID of the cabinet sensor.
+@param: fallback (dict) - Value to return if VolumeInfo drawer is missing. Defaults to {}.
+@returns: JSON Object - The 'AI_Cabinet_VolumeInfo' metadata block, or fallback if not found.
+@note: Depends on cabinet_variables() for safe extraction. Caller must | from_json the result.
+@usage: {{ cabinet_volume_info('sensor.ai_cabinet') | from_json() }}
+        {{ cabinet_volume_info('sensor.unknown', {'error': 'missing'}) | from_json() }}
+
+"Cabinet Header Extractor" for the VolumeInfo block — the metadata and validation layer of a cabinet.
+Purpose: Provides safe, single-call access to cabinet identity metadata without manually navigating the variables structure.
+Input: entity_id (string): The full Home Assistant entity ID (e.g., sensor.kitchen_cabinet).
+Logic: Calls cabinet_variables(entity_id) to safely extract the variables attribute.
+       Then retrieves the 'AI_Cabinet_VolumeInfo' drawer from the result.
+
+The VolumeInfo block contains: id (GUID), version, friendly_name, description, flags, validation signature.
+Only the header metadata is exposed; the full drawer volume remains encapsulated.
+
+Output: A JSON-formatted string of the VolumeInfo metadata block (or fallback if drawer is missing).
+Technical Note: By using to_json(pretty_print=true), the output is optimized for debugging in the Developer Tools.
+-#}
+{%- macro cabinet_volume_info(entity_id, fallback = {}) -%}
+    {%- set rv = cabinet_drawer_value(entity_id, 'AI_Cabinet_VolumeInfo', fallback) | from_json() -%}
+    {{- rv | to_json(pretty_print=true) -}}
+{%- endmacro -%}
+
+{#-
+@macro: cabinet_volume_info_exists
+@desc: Checks if a cabinet has valid AI_Cabinet_VolumeInfo metadata.
+@param: entity_id (string) - The full HA entity ID of the cabinet sensor.
+@returns: JSON String - Boolean ("true" or "false").
+@note: Returns true only if VolumeInfo exists and is not none/null.
+@usage: {% if (cabinet_volume_info_exists('sensor.ai_cabinet') | from_json) %}
+-#}
+{%- macro cabinet_volume_info_exists(entity_id) -%}
+    {%- set _vi = cabinet_volume_info(entity_id, none) -%}
+    {%- set rv = _vi is not none -%}
+    {{- rv | to_json(pretty_print=true) -}}
+{%- endmacro -%}
+{#-
+"Cabinet Metadata Validator" that checks for the presence of VolumeInfo.
+Purpose: Safely determines if a cabinet sensor contains valid metadata before attempting to use it.
+Input: entity_id (string): The cabinet sensor entity ID.
+Logic: Fetches VolumeInfo using cabinet_volume_info() with a none fallback.
+       Checks if the result is not none (indicating successful retrieval).
+Output: A JSON-formatted boolean string ("true" or "false").
+-#}
+{%- macro cabinet_volume_info_exists(entity_id) -%}
+    {%- set _vi = cabinet_volume_info(entity_id, none) -%}
+    {%- set rv = _vi is not none -%}
+    {{- rv | to_json(pretty_print=true) -}}
+{%- endmacro -%}
+
+{#-
+@macro: cabinet_members
+@desc: Retrieves the members list or dict from a cabinet's 'members' drawer.
+@param: entity_id (string) - The full HA entity ID of the cabinet sensor.
+@param: fallback (dict) - Value to return if members drawer is missing. Defaults to {}.
+@returns: JSON Object - The members data structure, or fallback if not found.
+@note: Assumes the cabinet follows the standard schema with a 'members' attribute drawer.
+@note: Members can be a dict or list; no specific structure is enforced.
+@usage: {{ cabinet_members('sensor.ai_cabinet') | from_json() }}
+        {{ cabinet_members('sensor.ai_cabinet', []) | from_json() }}
+
+"Cabinet Members Accessor" for retrieving the members collection from a cabinet.
+Purpose: Provides convenient access to the members drawer without manual dict traversal.
+Input: entity_id (string): The cabinet sensor entity ID.
+       fallback (dict): Default value if the members drawer doesn't exist.
+Logic: Uses cabinet_drawer_value() to fetch the 'members' drawer's value field.
+       Returns the members data structure as-is, or fallback if missing.
+Output: A JSON-formatted string of the members data (or fallback if not found).
+-#}
+{%- macro cabinet_members(entity_id, fallback = {}) -%}
+    {%- set rv = cabinet_drawer_value(entity_id, 'members', fallback) | from_json() -%}
+    {{- rv | to_json(pretty_print=true) -}}
+{%- endmacro -%}
+
+{#-
+@macro: cabinet_guid
+@desc: Extracts the GUID identifier from a cabinet's AI_Cabinet_VolumeInfo metadata.
+@param: entity_id (string) - The full HA entity ID of the cabinet sensor.
+@param: fallback (string) - Value to return if GUID is not found. Defaults to ''.
+@returns: String - The GUID/ID value from VolumeInfo, or fallback if not found.
+@note: Looks for the 'id' field within VolumeInfo.
+@note: Safely handles missing metadata by returning fallback; does not output JSON.
+@usage: {{ cabinet_guid('sensor.ai_cabinet') }}
+        {{ cabinet_guid('sensor.ai_cabinet', 'unknown') }}
+
+"Cabinet GUID Extractor" for retrieving the unique identifier from a cabinet's metadata block.
+Purpose: Provides direct access to a cabinet's identity (GUID/ID) from its VolumeInfo metadata without manual traversal.
+Input: entity_id (string): The cabinet sensor entity ID.
+       fallback (string): Default if the ID/GUID is not present or metadata is missing.
+Logic: Fetches the VolumeInfo drawer's value using cabinet_drawer_value().
+       Extracts the 'id' field from VolumeInfo.
+       Safely handles missing or null values, returning fallback.
+Output: A plain string GUID (not JSON-encoded), trimmed of whitespace.
+-#}
+{%- macro cabinet_guid(entity_id, fallback='') -%}
+    {%- set _vi_val = cabinet_drawer_value(entity_id, 'AI_Cabinet_VolumeInfo') | from_json() -%}
+    {%- set _guid = _vi_val.get('id', fallback) | string | trim -%}
+    {{- _guid -}}
+{%- endmacro -%}
+
+{#-
+@macro: cabinet_guid_compat
+@desc: Extracts the GUID from a cabinet's VolumeInfo with backward compatibility fallback.
+@param: entity_id (string) - The full HA entity ID of the cabinet sensor.
+@param: fallback (string) - Value to return if GUID/guid is not found. Defaults to ''.
+@returns: String - The GUID value from VolumeInfo (tries 'id' first, then 'guid'), or fallback if not found.
+@note: Provides compatibility for cabinets using either 'id' or 'guid' field names.
+@note: Does not output JSON; returns a plain trimmed string.
+@usage: {{ cabinet_guid_compat('sensor.ai_cabinet') }}
+        {{ cabinet_guid_compat('sensor.ai_cabinet', 'unknown') }}
+
+"Cabinet GUID Extractor with Compatibility" for retrieving GUID from cabinets using different field naming conventions.
+Purpose: Supports legacy or alternate cabinet schemas where the GUID field may be named 'id' or 'guid'.
+Input: entity_id (string): The cabinet sensor entity ID.
+       fallback (string): Default if neither 'id' nor 'guid' fields are present.
+Logic: Fetches the VolumeInfo drawer's value using cabinet_drawer_value().
+       Attempts to extract the 'id' field first.
+       Falls back to 'guid' field if 'id' is not found.
+       Returns fallback if neither field exists.
+Output: A plain string GUID (not JSON-encoded), trimmed of whitespace.
+-#}
+{%- macro cabinet_guid_compat(entity_id, fallback='') -%}
+    {%- set _vi_val = cabinet_drawer_value(entity_id, 'AI_Cabinet_VolumeInfo') | from_json() -%}
+    {%- set _guid = _vi_val.get('id', _vi_val.get('guid', fallback)) | string | trim -%}
+    {{- _guid -}}
+{%- endmacro -%}
+
+{#-
+@macro: cabinet_friendly_name
+@desc: Extracts the user-friendly name from a cabinet's AI_Cabinet_VolumeInfo metadata.
+@param: entity_id (string) - The full HA entity ID of the cabinet sensor.
+@param: fallback (string) - Value to return if friendly_name is not found. Defaults to ''.
+@returns: String - The friendly_name from VolumeInfo, or fallback if not found.
+@note: Provides a human-readable label for the cabinet distinct from the entity ID.
+@note: Does not output JSON; returns a plain string.
+@usage: {{ cabinet_friendly_name('sensor.ai_cabinet') }}
+        {{ cabinet_friendly_name('sensor.unknown', 'Unnamed Cabinet') }}
+
+"Cabinet Friendly Name Extractor" for retrieving the user-facing name from cabinet metadata.
+Purpose: Provides easy access to a cabinet's display name for UI rendering or logging.
+Input: entity_id (string): The cabinet sensor entity ID.
+       fallback (string): Default if the friendly_name field is not present.
+Logic: Fetches the VolumeInfo drawer's value using cabinet_drawer_value().
+       Extracts the 'friendly_name' field from VolumeInfo.
+       Returns fallback if the field is missing or null.
+Output: A plain string (not JSON-encoded).
+-#}
+{%- macro cabinet_friendly_name(entity_id, fallback='') -%}
+    {%- set _vi_val = cabinet_drawer_value(entity_id, 'AI_Cabinet_VolumeInfo') | from_json() -%}
+    {%- set _guid = _vi_val.get('friendly_name', fallback) -%}
+    {{- _guid -}}
+{%- endmacro -%}
+
+
+{#-
+@macro: cabinet_guid_new
+@desc: Generates a new random GUID in standard UUID-like format (8-4-4-4-12 hex digits).
+@param: None
+@returns: String - A randomly generated GUID string (e.g., '1a2b-3c4d-5e6f-7a8b-9c0d1e2f3a4b').
+@note: Uses Jinja's random filter to generate numeric parts; not cryptographically secure.
+@note: For non-security applications like temporary IDs or test data only.
+@usage: {{ cabinet_guid_new() }}
+
+"Random GUID Generator" for creating new cabinet identifiers.
+Purpose: Generates a new random GUID suitable for assigning unique identifiers to cabinets or volumes.
+Input: None
+Logic: Uses range() and random filter to generate 8 random 16-bit integers.
+       Formats them into a standard GUID structure with hyphens.
+Output: A plain string GUID in the format '8hex-4hex-4hex-4hex-12hex'.
+Technical Note: Not cryptographically secure; use for non-critical applications.
+-#}
+{%- macro cabinet_guid_new() -%}
+    {{- '%04x%04x-%04x-%04x-%04x-%04x%04x%04x'
+    | format(
+        range(0, 65536) | random, range(0, 65536) | random,
+        range(0, 65536) | random, range(0, 65536) | random,
+        range(0, 65536) | random, range(0, 65536) | random,
+        range(0, 65536) | random, range(0, 65536) | random
+    ) -}}
+{%- endmacro -%}
+
+{#-
+@macro: cabinet_guid_new_v4
+@desc: Generates a new UUID v4-compatible random GUID with version and variant bits set correctly.
+@param: None
+@returns: String - A randomly generated UUID v4 string (e.g., '1a2b3c4d-5e6f-4a7b-8c9d-0e1f2a3b4c5d').
+@note: Sets version bits to 4 and variant bits to 8 for RFC 4122 compliance.
+@note: Uses Jinja's random filter; not cryptographically secure but suitable for non-security use cases.
+@usage: {{ cabinet_guid_new_v4() }}
+
+"UUID v4 Compatible GUID Generator" for creating RFC 4122 compliant random GUIDs.
+Purpose: Generates a new random GUID with proper UUID v4 version and variant bits set for standards compliance.
+Input: None
+Logic: Generates random 16-bit integers for the first part (p1a, p1b) and second part (p2).
+       Generates random 12-bit integers for the version-sensitive parts (p3, p4).
+       Generates random 16-bit integers for the final two parts (p5, p6a, p6b).
+       Formats with version bit '4' in the third segment and variant bit '8' in the fourth segment.
+Output: A plain string GUID in RFC 4122 v4 format: '8hex-4hex-4vhex-8vhex-12hex'.
+Technical Note: The format string '4' and '8' represent literal version/variant bits; random parts fill remaining hex digits.
+-#}
+{%- macro cabinet_guid_new_v4() -%}
+    {%- set p1a = range(0, 65536) | random -%}
+    {%- set p1b = range(0, 65536) | random -%}
+    {%- set p2  = range(0, 65536) | random -%}
+    {%- set p3  = range(0, 4096)  | random -%}
+    {%- set p4  = range(0, 4096)  | random -%}
+    {%- set p5  = range(0, 65536) | random -%}
+    {%- set p6a = range(0, 65536) | random -%}
+    {%- set p6b = range(0, 65536) | random -%}
+    {{- '%04x%04x-%04x-4%03x-8%03x-%04x%04x%04x' | format(p1a, p1b, p2, p3, p4, p5, p6a, p6b) -}}
+{%- endmacro -%}
+
+{#-
+@macro: cabinet_acls
+@desc: Retrieves the access control list (ACLs) from a cabinet's AI_Cabinet_VolumeInfo metadata.
+@param: entity_id (string) - The full HA entity ID of the cabinet sensor.
+@param: fallback (dict) - Value to return if ACLs are not found. Defaults to {}.
+@returns: JSON Object - The ACLs data structure, or fallback if not found.
+@note: ACLs define permissions and access rules for the cabinet.
+@note: Assumes the cabinet follows the standard schema with VolumeInfo containing an 'acls' field.
+@usage: {{ cabinet_acls('sensor.ai_cabinet') | from_json() }}
+        {{ cabinet_acls('sensor.ai_cabinet', {'default': 'deny'}) | from_json() }}
+
+"Cabinet ACLs Accessor" for retrieving access control list metadata from a cabinet.
+Purpose: Provides convenient access to the permission/authorization data stored in a cabinet's metadata.
+Input: entity_id (string): The cabinet sensor entity ID.
+       fallback (dict): Default value if the ACLs field doesn't exist.
+Logic: Fetches the VolumeInfo drawer's value using cabinet_drawer_value().
+       Extracts the 'acls' field from VolumeInfo.
+       Returns the ACLs data structure as-is, or fallback if missing.
+Output: A JSON-formatted string of the ACLs data (or fallback if not found).
+-#}
+{%- macro cabinet_acls(entity_id, fallback={}) -%}
+    {%- set _vi_val = cabinet_drawer_value(entity_id, 'AI_Cabinet_VolumeInfo') | from_json() -%}
+    {%- set _acls = _vi_val.get('acls', fallback) -%}
+    {{- _acls | to_json(pretty_print=true) -}}
+{%- endmacro -%}
+
+{#- </editor-fold> -#}
+
+{#- <editor-fold desc="UTILITIES" defaultstate="collapsed"> -#}
+
+{#-
+@macro: safe_parse_json_string
+@desc: Safely parses a string that may contain JSON.
+@param: raw (string) - Raw input that might be JSON.
+@param: fallback (any) - Value if parsing fails.
+@returns: Parsed object or fallback.
+@usage: {% set data = safe_parse_json_string(my_string, {}) %}
+-#}
+{%- macro safe_parse_json_string(raw, fallback={}) -%}
+    {%- if raw is string -%}
+        {{- raw | from_json(default=fallback) | tojson -}}
+        {%- elif raw is mapping -%}
+        {{- raw | tojson -}}
+    {%- else -%}
+        {{- fallback | tojson -}}
+    {%- endif -%}
+{%- endmacro -%}
+
+{#-
+@macro: safe_get_nested
+@desc: Safely traverses a nested dict/object structure.
+@param: obj (any) - Starting object (dict, JSON string, or other).
+@param: keys (list) - Path of keys to traverse.
+@param: fallback (any) - Value if path doesn't exist.
+@returns: JSON String - Value at path, or fallback.
+@usage: {{ safe_get_nested(state_attr('sensor.x', 'variables'), ['drawer', 'value', 'ts'], '') | from_json }}
+-#}
+{%- macro safe_get_nested(obj, keys, fallback='') -%}
+    {%- set current = obj -%}
+
+    {%- if current is string -%}
+        {%- set current = current | from_json(default={}) -%}
+    {%- endif -%}
+
+    {%- for key in keys if current is mapping -%}
+        {%- set current = current.get(key) -%}
+    {%- endfor -%}
+
+    {{- (current if current is not none else fallback) | tojson -}}
+{%- endmacro -%}
+
+{#- </editor-fold> -#}

--- a/custom_templates/zenos_ai/zenos_cabinets.jinja
+++ b/custom_templates/zenos_ai/zenos_cabinets.jinja
@@ -1,0 +1,308 @@
+{#- zenos_cabinets.jinja -#}
+
+{#- <editor-fold desc="Docs" defaultstate="collapsed"> -#}
+{#- <editor-fold desc="API" defaultstate="collapsed"> -#}
+
+{#
+-----------------
+ZENOS CABINET API
+-----------------
+cabinet_list_from_label(cabinet_label)
+  Returns all sensor entities associated with a specific label.
+
+cabinet_id_from_label(cabinet_label, default_return)
+  Resolves a label to a single primary cabinet sensor entity ID.
+
+cabinet_id_from_slot(cabinet_slot, default_return)
+  Maps a physical slot designation to a specific entity ID.
+
+cabinet_variables(entity_id)
+  Extracts the 'variables' attribute dict from a known entity.
+  Returns the 'variables' attribute dict as JSON.
+  Safety: Returns {} if entity is unavailable.
+
+cabinet_variables_from_label(cabinet_label)
+  Resolves a label and extracts its variables in one step.
+  Returns the 'variables' attribute dict as JSON.
+  Safety: Depends on cabinet_id_from_label logic.
+#}
+{#- </editor-fold> -#}
+
+
+{#- <editor-fold desc="Assumptions" defaultstate="collapsed"> -#}
+
+{#-
+@assumptions: A Cabinet using these macros ALWAYS has the following structure
+
+    state: Variables
+
+    attributes:
+
+      # icon and friendly_name populated from HA-Template-Configuration
+      icon: mdi:file-cabinet
+      friendly_name: ZenOS Default AI User Cabinet
+
+      # [boolean] Indicates if attributes are to be timestampped
+      default_timestamp: true
+
+      # [boolean] Indicates if attribute changes should be logged to the logbook
+      log_events: false
+
+      # [dict] Data storage for the cabinet template sensor
+      variables:
+
+          attr_1:
+            # value: [string|list|dict] The Value of 'attr_1' [optional]
+            value: {}
+            # timestamp: [string|null] last modified datetime of 'attr_1' [optional]
+            timestamp: '2026-03-12T19:40:11.060327-07:00'
+
+          attr_2:
+            value: 'string-value'
+            timestamp: null
+
+          attr_3:
+            value:
+            - list-item-1
+            - list-item-2
+
+          attr_n:
+            value: ...
+-#}
+{#- </editor-fold> -#}
+
+{#- </editor-fold> -#}
+
+{#- <editor-fold desc="Cabinet Helpers" defaultstate="collapsed"> -#}
+
+{#-
+@macro: cabinet_list_from_label
+@desc: Retrieves a comprehensive list of all 'sensor' domain entities matching a specific label.
+@param: cabinet_label (string) - The HA label to query.
+@returns: JSON Array - A list of entity IDs.
+@usage: {{ cabinet_list_from_label('kitchen_storage') | from_json() }}
+-#}
+{%- macro cabinet_list_from_label(cabinet_label) -%}
+    {{- label_entities(cabinet_label)
+    | select('match', 'sensor[.]')
+    | list
+    | to_json(pretty_print=true) -}}
+{%- endmacro -%}
+
+{#-
+@macro: cabinet_id_from_label
+@desc: Resolves a label to the first available 'sensor' entity ID found.
+@param: cabinet_label (string) - The HA label to query.
+@param: default_return (any) - Value to return if no entity is matched. Defaults to ''.
+@returns: String - The entity ID (e.g., 'sensor.cabinet_1') or default_return.
+@note: Uses character class [.] for regex safety.
+   Not using any of the following variants here
+    1. | select('match', 'sensor.')
+    2. | select('match', 'sensor\.')
+    3. | select('match', 'sensor\\.')
+    Character Class: [.] Is cleaner to read and avoids backslash confusion entirely.
+@caveat: | first will only ever give you the one that comes first alphabetically.
+@note: label_entities ALWAYS returns a list and usually returns IDs in the order they were assigned or created, which often happens to be alphabetical
+@usage: {{ cabinet_id_from_label('tool_chest', 'sensor.none') | from_json() }}
+-#}
+{%- macro cabinet_id_from_label(cabinet_label, default_return='') -%}
+    {{- label_entities(cabinet_label)
+    | select('match', 'sensor[.]')
+    | list
+    | first
+    | default(default_return) -}}
+{%- endmacro -%}
+
+{#-
+@macro: cabinet_id_from_slot
+@desc: Cross-references a cabinet slot designation against the ZenOS health configuration.
+@param: cabinet_slot (string) - The slot identifier to look up.
+@param: default_return (any) - Value to return if slot is not mapped.
+@returns: String - The mapped entity ID.
+@usage: {{ cabinet_id_from_slot('ai_user') }}
+-#}
+{%- macro cabinet_id_from_slot(cabinet_slot, default_return='') -%}
+    {%- import 'zenos_ai/zenos_health.jinja' as HEALTH -%}
+    {%- set slot_to_default_entity = HEALTH.slot_to_default_entity() | from_json() -%}
+    {{- slot_to_default_entity.get(cabinet_slot) | default(default_return) -}}
+{%- endmacro -%}
+
+
+
+{#-
+@macro: cabinet_variables
+@desc: Safe getter for the 'variables' attribute of a ZenOS schema cabinet.
+@param: entity_id (string) - The full HA entity ID.
+@param: fallback (dict) - Value to return if entity is missing, invalid, or 'variables' is undefined/falsy. Defaults to {}.
+@returns: JSON Object - The 'variables' dictionary, or fallback if entity is invalid.
+@note: Performs has_value() check before attempting extraction.
+@note: Uses | default(fallback, true) to treat any falsy value (none, false, "", [], {}) as needing the fallback.
+@usage: {{ cabinet_variables('sensor.ai_cabinet') | from_json() }}
+        {{ cabinet_variables('sensor.unknown', {'error': 'missing'}) | from_json() }}
+
+"Safe Getter" for the complex nested data structure defined in ZenOS cabinet schema.
+Purpose: Retrieves the variables attribute from a specific sensor entity while providing safety checks to prevent template errors.
+Input: entity_id (string): The full Home Assistant entity ID (e.g., sensor.kitchen_cabinet).
+Logic: Checks if the entity_id is provided and if the entity currently exists/has a valid state in the state machine using has_value().
+       If the entity is valid, extracts the variables attribute with defensive fallback for any falsy result.
+
+Fallback Behavior: The second parameter of | default(fallback, true) ensures that not only missing attributes,
+       but also null, false, empty strings, empty lists, and empty dicts are replaced with the fallback value.
+       This is critical for cabinet handling where an empty/undefined variables attribute should always resolve to {}.
+
+Output: A JSON-formatted string of the variables dictionary (or fallback if entity is missing/invalid).
+Technical Note: By using to_json(pretty_print=true), the output is optimized for debugging in the Developer Tools or for being passed into fields that expect a JSON string.
+-#}
+{%- macro cabinet_variables(entity_id, fallback = {}) -%}
+    {%- set rv = fallback -%}
+    {%- if entity_id and has_value(entity_id) -%}
+        {%- set rv = state_attr(entity_id, 'variables') | default(fallback, true) -%}
+    {%- endif -%}
+    {{- rv | to_json(pretty_print=true) -}}
+{%- endmacro -%}
+
+{#-
+@macro: cabinet_variables_from_label
+@desc: High-level wrapper to fetch cabinet data directly via a label.
+@param: cabinet_label (string) - The HA label assigned to the cabinet.
+@returns: JSON Object - The 'variables' dictionary.
+@usage: {{ cabinet_variables_from_label('primary_storage') | from_json() }}
+
+"High-Level Wrapper" that abstracts away the need to know the specific entity ID, relying instead on Home Assistant's organizational labels.
+
+Purpose: Finds the primary sensor associated with a label and returns its stored variables in one call.
+
+Input: cabinet_label (string): The slug or name of the Home Assistant label assigned to the cabinet sensor.
+
+Logic: Calls cabinet_id_from_label(cabinet_label) to resolve the label into a specific sensor. entity ID.
+        Passes that ID into cabinet_variables(entity_id).
+
+Output: A JSON-formatted string of the variables dictionary (or an empty JSON object if no entity is found for that label).
+-#}
+{%- macro cabinet_variables_from_label(cabinet_label) -%}
+    {%- set entity_id = cabinet_id_from_label(cabinet_label) -%}
+    {{- cabinet_variables(entity_id) -}}
+{%- endmacro -%}
+
+
+{#- </editor-fold> -#}
+
+{#- <editor-fold desc="Cabinet Drawer Helpers" defaultstate="collapsed"> -#}
+
+
+
+{#-
+@macro: cabinet_drawer_exists
+@desc: Checks if a drawer key exists in a cabinet's variables.
+@param: entity_id (string) - Cabinet sensor entity ID.
+@param: drawer_key (string) - Drawer key to check.
+@returns: JSON String - Boolean ("true" or "false").
+@usage: {% if (cabinet_drawer_exists('sensor.ai_cabinet', 'essence') | from_json) %}
+-#}
+{%- macro cabinet_drawer_exists(entity_id, drawer_key) -%}
+    {%- set vars = cabinet_variables(entity_id) | from_json -%}
+    {{- (drawer_key in vars) | to_json(pretty_print=true) -}}
+{%- endmacro -%}
+
+
+{#-
+@macro: cabinet_drawer
+@desc: Retrieves a drawer (attribute dict) from a cabinet's variables by key.
+@param: entity_id (string) - Cabinet sensor entity ID.
+@param: drawer_key (string) - The key name of the drawer to retrieve.
+@param: fallback (dict) - Value to return if drawer_key is not found. Defaults to {}.
+@returns: JSON Object - The drawer dictionary, or fallback if not found.
+@note: Handles JSON-encoded string values within the drawer by automatically parsing them.
+@note: If the drawer itself is a JSON string, it will be parsed; if parsing fails, fallback is used.
+@usage: {{ cabinet_drawer('sensor.ai_cabinet', 'essence') | from_json() }}
+        {{ cabinet_drawer('sensor.ai_cabinet', 'missing_drawer', {'error': 'not_found'}) | from_json() }}
+
+"Drawer Accessor" for retrieving a single attribute-dict from the cabinet's variables structure.
+Purpose: Provides safe access to any named drawer within a cabinet without manual dict traversal.
+Input: entity_id (string): The cabinet sensor entity ID.
+       drawer_key (string): The name of the drawer (e.g., 'essence', 'metadata', 'config').
+       fallback (dict): Default value if the drawer doesn't exist.
+Logic: Fetches the full variables dict using cabinet_variables().
+       Retrieves the drawer by key, defaulting to fallback if missing.
+       Detects and auto-parses JSON-encoded strings within the drawer value to handle legacy or nested encoding.
+Output: A JSON-formatted string of the drawer (or fallback if not found).
+-#}
+{%- macro cabinet_drawer(entity_id, drawer_key, fallback={}) -%}
+    {%- set vars = cabinet_variables(entity_id) | from_json -%}
+    {%- set drawer = vars.get(drawer_key, fallback) -%}
+    {#- Note that in some cabinets, the data under 'drawer_key' might be a JSON encoded string -#}
+    {%- if drawer is string -%}
+        {%- set drawer = drawer | from_json(fallback) -%}
+    {%- endif -%}
+    {{- drawer | to_json(pretty_print=true) -}}
+{%- endmacro -%}
+
+
+{#-
+@macro: cabinet_drawer_value
+@desc: Extracts the 'value' field from a named drawer in a cabinet's variables.
+@param: entity_id (string) - Cabinet sensor entity ID.
+@param: drawer_key (string) - The key name of the drawer to access.
+@param: fallback (any) - Value to return if 'value' field is not found. Defaults to {}.
+@returns: JSON Object/String - The 'value' field from the drawer, or fallback if not found.
+@note: Handles both JSON-encoded string values at the drawer level and within the 'value' field.
+@note: Useful for extracting stored data from cabinet attributes that follow the {value, timestamp} pattern.
+@usage: {{ cabinet_drawer_value('sensor.ai_cabinet', 'essence') | from_json() }}
+        {{ cabinet_drawer_value('sensor.ai_cabinet', 'config', {}) | from_json() }}
+
+"Drawer Value Extractor" for accessing the 'value' field specifically from a drawer.
+Purpose: Simplifies access to the data payload stored in cabinet attributes that follow the {value, timestamp} structure.
+Input: entity_id (string): The cabinet sensor entity ID.
+       drawer_key (string): The name of the drawer containing the value.
+       fallback (any): Default if the value field doesn't exist.
+Logic: Fetches the full drawer using cabinet_drawer().
+       Extracts the 'value' field from the drawer dict.
+       Handles JSON-encoded strings within the value field for nested encoding scenarios.
+Output: A JSON-formatted string of the value (or fallback if missing).
+-#}
+{%- macro cabinet_drawer_value(entity_id, drawer_key, fallback={}) -%}
+    {%- set drawer = cabinet_drawer(entity_id, drawer_key, {}) | from_json -%}
+    {%- set value = drawer.get('value', fallback) -%}
+    {#- Note that in some cabinets, the data under 'drawer_key'->'value' might be a JSON encoded string -#}
+    {%- if value is string -%}
+        {%- set value = value | from_json(fallback) -%}
+    {%- endif -%}
+    {{- value | to_json(pretty_print=true) -}}
+{%- endmacro -%}
+
+
+{#- </editor-fold> -#}
+
+{#- <editor-fold desc="Volume Drawer Helpers" defaultstate="collapsed"> -#}
+
+
+{#-
+@macro: volume_drawer
+@desc: Retrieves a drawer (attribute dict) from a volume object by key.
+@param: volume (dict) - The volume dictionary to access.
+@param: drawer_key (string) - The key name of the drawer to retrieve.
+@param: fallback (dict) - Value to return if drawer_key is not found. Defaults to {}.
+@returns: JSON Object - The drawer dictionary, or fallback if not found.
+@note: Handles JSON-encoded string values within the drawer by automatically parsing them.
+@note: Operates on a volume dict directly (rather than fetching from an entity), suitable for processing volume collections.
+@usage: {{ volume_drawer(my_volume, 'metadata') | from_json() }}
+        {{ volume_drawer(my_volume, 'missing', {'error': 'not_found'}) | from_json() }}
+
+"Volume Drawer Accessor" for retrieving a single attribute-dict from a volume object.
+Purpose: Parallels cabinet_drawer() but operates on a pre-fetched volume dict instead of an entity ID.
+Input: volume (dict): The volume object (e.g., from iterating over a volumes list).
+       drawer_key (string): The name of the drawer within the volume.
+       fallback (dict): Default value if the drawer doesn't exist.
+Logic: Retrieves the drawer from the volume dict by key, defaulting to fallback if missing.
+       Detects and auto-parses JSON-encoded strings within the drawer value.
+Output: A JSON-formatted string of the drawer (or fallback if not found).
+-#}
+{%- macro volume_drawer(volume, drawer_key, fallback={}) -%}
+    {%- set drawer = volume.get(drawer_key, fallback) -%}
+    {#- Note that in some cabinets, the data under 'drawer_key' might be a JSON encoded string -#}
+    {%- if drawer is string -%}
+        {%- set drawer = drawer | from_json(fallback) -%}
+    {%- endif -%}
+    {{- drawer | to_json(pretty_print=true) -}}
+{%- endmacro -%}
+

--- a/custom_templates/zenos_ai/zenos_cabinets.jinja
+++ b/custom_templates/zenos_ai/zenos_cabinets.jinja
@@ -263,6 +263,10 @@ Logic: Fetches the full drawer using cabinet_drawer().
        Extracts the 'value' field from the drawer dict.
        Handles JSON-encoded strings within the value field for nested encoding scenarios.
 Output: A JSON-formatted string of the value (or fallback if missing).
+
+Encapsulates: FG-38 safe: two-round normalization to handle cases where either the drawer
+             or the value is a JSON-encoded string, ensuring that the final output is always
+             a properly parsed JSON structure or the provided fallback.
 -#}
 {%- macro cabinet_drawer_value(entity_id, drawer_key, fallback={}) -%}
     {%- set drawer = cabinet_drawer(entity_id, drawer_key, {}) | from_json -%}

--- a/custom_templates/zenos_ai/zenos_health.jinja
+++ b/custom_templates/zenos_ai/zenos_health.jinja
@@ -132,6 +132,7 @@ Provides mapping of slots to default entities
 #######################################################################
 -#}
 {%- macro essence_probe(cab) -%}
+  {#-
   {%- set _av = state_attr(cab, 'variables') | default({}, true)
                 if (cab != '' and cab not in ['unknown','unavailable']
                     and states(cab) not in ['unknown','unavailable'])
@@ -139,6 +140,10 @@ Provides mapping of slots to default entities
   {%- set _raw = _av.get('zenai_essence', {}) if _av is mapping else {} -%}
   {%- set _r1  = _raw.get('value', _raw) if _raw is mapping else {} -%}
   {%- set _ev  = _r1 if _r1 is mapping else (_r1 | from_json if _r1 is string else {}) -%}
+  -#}
+  {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
+  {%- set _ev = CABS.cabinet_drawer_value(cab, 'zenai_essence') | from_json() -%}
+
   {%- if not (_ev is mapping and _ev) -%}
     {{- {'schema': 'empty', 'valid': false, 'name': '', 'guid': '', 'jacket_id': '',
          'signed_by': '', 'signed_by_ok': false,

--- a/packages/zenos_ai/dojotools/dojotools_admintools.yaml
+++ b/packages/zenos_ai/dojotools/dojotools_admintools.yaml
@@ -366,11 +366,8 @@ script:
       then:
         - variables:
             _rtt_sys_wl_raw: >-
-              {%- set _sv = state_attr(_rtt_system, 'variables') | default({}) -%}
-              {%- set _sv = _sv if _sv is mapping else {} -%}
-              {%- set _wr = _sv.get('zen_summarizer_act_whitelist', {}) -%}
-              {%- set _wv1 = _wr.get('value', _wr) if _wr is mapping else {} -%}
-              {{ (_wv1 | from_json) if _wv1 is string else _wv1 }}
+              {%- import 'zenos_cabinets.jinja' as CABS -%}
+              {{- CABS.cabinet_drawer_value(_rtt_system, 'zen_summarizer_act_whitelist', {}) | from_json() }}
             _rtt_sys_whitelist_exists: >-
               {{- _rtt_sys_wl_raw is mapping and _rtt_sys_wl_raw.keys() | list | length > 0 -}}
         - if: "{{- not _rtt_sys_whitelist_exists -}}"
@@ -446,11 +443,8 @@ script:
     # Read current whitelist — state_attr direct (filecabinet blocks all syscab writes)
     - variables:
         _wl_raw: >-
-          {%- set _sv = state_attr(_system, 'variables') | default({}) -%}
-          {%- set _sv = _sv if _sv is mapping else {} -%}
-          {%- set _wr = _sv.get('zen_summarizer_act_whitelist', {}) -%}
-          {%- set _wv1 = _wr.get('value', _wr) if _wr is mapping else {} -%}
-          {{ (_wv1 | from_json) if _wv1 is string else _wv1 }}
+          {%- import 'zenos_cabinets.jinja' as CABS -%}
+          {{- CABS.cabinet_drawer_value(_system, 'zen_summarizer_act_whitelist', {}) | from_json() -}}
         _wl_current: >-
           {%- set w = _wl_raw if _wl_raw is mapping else {} -%}
           {{ w.get('allowed_events', []) if w is mapping else [] }}

--- a/packages/zenos_ai/dojotools/dojotools_admintools.yaml
+++ b/packages/zenos_ai/dojotools/dojotools_admintools.yaml
@@ -1208,10 +1208,10 @@ script:
           #_syscab_mapped: "{{- _syscab_vars if _syscab_vars is mapping else {} -}}"
           #_csve: "{{ _syscab_mapped.get('cab_schema_version', {}) }}"
           #_csve_mapped: "{{- _csve if _csve is mapping else {} -}}"
-          _csve_mapped: >
+          #_current_v: "{{- _csve_mapped.get('value', 0) | int(0) -}}"
+          _current_v: >
             {%- import 'zenos_cabinets.jinja' as CABS -%}
-            {{- CABS.cabinet_drawer_value('sensor.zenos_system_cabinet', 'cab_schema_version', {}) | from_json() -}}
-          _current_v: "{{- _csve_mapped.get('value', 0) | int(0) -}}"
+            {{- CABS.cabinet_drawer_value('sensor.zenos_system_cabinet', 'cab_schema_version', 0) | from_json() | int(0) -}}
           _new_v: "{{- schema_version | default(none) | int(-1) if schema_version | default(none) is not none else (1 if _current_v == 0 else 0) -}}"
       - event: set_variable_legacy
         event_data:

--- a/packages/zenos_ai/dojotools/dojotools_admintools.yaml
+++ b/packages/zenos_ai/dojotools/dojotools_admintools.yaml
@@ -366,7 +366,7 @@ script:
       then:
         - variables:
             _rtt_sys_wl_raw: >-
-              {%- import 'zenos_cabinets.jinja' as CABS -%}
+              {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
               {{- CABS.cabinet_drawer_value(_rtt_system, 'zen_summarizer_act_whitelist', {}) | from_json() }}
             _rtt_sys_whitelist_exists: >-
               {{- _rtt_sys_wl_raw is mapping and _rtt_sys_wl_raw.keys() | list | length > 0 -}}
@@ -443,7 +443,7 @@ script:
     # Read current whitelist — state_attr direct (filecabinet blocks all syscab writes)
     - variables:
         _wl_raw: >-
-          {%- import 'zenos_cabinets.jinja' as CABS -%}
+          {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
           {{- CABS.cabinet_drawer_value(_system, 'zen_summarizer_act_whitelist', {}) | from_json() -}}
         _wl_current: >-
           {%- set w = _wl_raw if _wl_raw is mapping else {} -%}
@@ -1023,7 +1023,7 @@ script:
                 #  {%- set r = _vi_raw.get('value', {}) if _vi_raw is mapping else {} -%}
                 #  {{ r if r is mapping else (r | from_json if r is string else {}) }}
                 _vi_val: >-
-                  {%- import 'zenos_cabinets.jinja' as CABS -%}
+                  {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
                   {{- CABS.cabinet_drawer_value(cab, 'AI_Cabinet_VolumeInfo', {}) | from_json() -}}
 
                 cabinet_guid: "{{- _vi_val.get('id', '') | string | trim -}}"
@@ -1210,7 +1210,7 @@ script:
           #_csve_mapped: "{{- _csve if _csve is mapping else {} -}}"
           #_current_v: "{{- _csve_mapped.get('value', 0) | int(0) -}}"
           _current_v: >
-            {%- import 'zenos_cabinets.jinja' as CABS -%}
+            {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
             {{- CABS.cabinet_drawer_value('sensor.zenos_system_cabinet', 'cab_schema_version', 0) | from_json() | int(0) -}}
           _new_v: "{{- schema_version | default(none) | int(-1) if schema_version | default(none) is not none else (1 if _current_v == 0 else 0) -}}"
       - event: set_variable_legacy
@@ -1489,7 +1489,7 @@ script:
             #  {%- set _val = info.get('value', {}) if info is mapping else {} -%}
             #  {%- set _val = _val if _val is mapping else (_val | from_json if _val is string else {}) -%}
             existing_guid: >-
-              {%- import 'zenos_cabinets.jinja' as CABS -%}
+              {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
               {%- set _val = CABS.cabinet_drawer_value(cabinet_entity, 'AI_Cabinet_VolumeInfo', {}) | from_json() -%}
               {{- _val.get('id', '') -}}
             guid_changed: "{{- force_new_guid or existing_guid != cabinet_guid -}}"
@@ -2892,7 +2892,7 @@ script:
         #_pl_vi_val: "{{- _pl_vi_val_raw if _pl_vi_val_raw is mapping else (_pl_vi_val_raw | from_json if _pl_vi_val_raw is string else {}) -}}"
 
         _pl_vi_val: >
-          {%- import 'zenos_cabinets.jinja' as CABS -%}
+          {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
           {{- CABS.cabinet_drawer_value('sensor.zenos_system_cabinet', 'AI_Cabinet_VolumeInfo', {}) | from_json() -}}
         _pl_flags: "{{- _pl_vi_val.get('flags', {}) -}}"
         _pl_flags_mapped: "{{- _pl_flags if _pl_flags is mapping else {} -}}"

--- a/packages/zenos_ai/dojotools/dojotools_admintools.yaml
+++ b/packages/zenos_ai/dojotools/dojotools_admintools.yaml
@@ -1186,6 +1186,7 @@ script:
           _all_cabs: >-
             {{- label_entities('Zen Cabinet' | slugify) | list -}}
       - variables:
+          # @TODO - Inconsistent behaviour - why is mount_status_result being returned without going one level deeper into the drawer->value ?
           mount_status_result: >-
             {%- set ns = namespace(m={}) -%}
             {%- for eid in _all_cabs -%}
@@ -1443,11 +1444,15 @@ script:
           response_variable: response
       - conditions:
         - condition: template
+          #value_template: >-
+          #  {{
+          #    state_attr(cabinet_entity, 'variables') is none
+          #    or 'AI_Cabinet_VolumeInfo' not in (state_attr(cabinet_entity, 'variables') | default({}))
+          #  }}
           value_template: >-
-            {{
-              state_attr(cabinet_entity, 'variables') is none
-              or 'AI_Cabinet_VolumeInfo' not in (state_attr(cabinet_entity, 'variables') | default({}))
-            }}
+            {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
+            {%- set vol = CABS.cabinet_variables(cabinet_entity, {}) | from_json() -%}
+            {{- 'AI_Cabinet_VolumeInfo' not in vol -}}
         alias: Initialize New Cabinet
         sequence:
         - repeat:

--- a/packages/zenos_ai/dojotools/dojotools_admintools.yaml
+++ b/packages/zenos_ai/dojotools/dojotools_admintools.yaml
@@ -1312,9 +1312,9 @@ script:
         now_iso: "{{- now().isoformat() -}}"
         schema_version: 1
         cabinet_guid: >
+          {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
           {{-
-            '%04x%04x-%04x-%04x-%04x-%04x%04x%04x' 
-              | format(range(0,65536)|random,range(0,65536)|random,range(0,65536)|random,range(0,65536)|random,range(0,65536)|random,range(0,65536)|random,range(0,65536)|random,range(0,65536)|random) 
+              CABS.cabinet_guid_new()
               if (force_new_guid or not cabinet_guid) 
               else cabinet_guid 
           -}}

--- a/packages/zenos_ai/dojotools/dojotools_admintools.yaml
+++ b/packages/zenos_ai/dojotools/dojotools_admintools.yaml
@@ -1009,9 +1009,12 @@ script:
                 response_variable: result
             # ── Classifier ─────────────────────────────────────────────────
             - variables:
+                #_vars: >-
+                #  {%- set v = state_attr(cab, 'variables') | default(none, true) -%}
+                #  {{ v if v is mapping else {} }}
                 _vars: >-
-                  {%- set v = state_attr(cab, 'variables') | default(none, true) -%}
-                  {{ v if v is mapping else {} }}
+                  {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
+                  {{- CABS.cabinet_variables(cab) | from_json() -}}
                 has_volumeinfo: "{{- 'AI_Cabinet_VolumeInfo' in _vars -}}"
                 has_label_index: "{{- '_label_index' in _vars -}}"
                 has_context:     "{{- '_context' in _vars -}}"
@@ -1186,14 +1189,19 @@ script:
           _all_cabs: >-
             {{- label_entities('Zen Cabinet' | slugify) | list -}}
       - variables:
-          # @TODO - Inconsistent behaviour - why is mount_status_result being returned without going one level deeper into the drawer->value ?
+          # @TODO - Inconsistent behaviour - why is mount_status_result being returned as a drawer without going one level deeper into the drawer->value ?
+          # @TODO - pretty sure we're never going to see 'mounted' as a key in 'meta' as 'meta' has only one key, and that is 'value'
           mount_status_result: >-
             {%- set ns = namespace(m={}) -%}
             {%- for eid in _all_cabs -%}
+              {#-
               {%- set _v = state_attr(eid, 'variables') | default({}, true) -%}
               {%- set _v = _v if _v is mapping else {} -%}
               {%- set _mt = _v.get('meta', {}) -%}
               {%- set _mt = _mt if _mt is mapping else (_mt | from_json if _mt is string else {}) -%}
+              -#}
+              {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
+              {%- set _mt = CABS.cabinet_drawer(cab, 'meta', {}) | from_json() -%}
               {%- set ns.m = ns.m | combine({eid: {'state': states(eid), 'mounted': _mt.get('mounted', false)}}) -%}
             {%- endfor -%}
             {{ ns.m | combine({'caller_token': caller_token}) }}

--- a/packages/zenos_ai/dojotools/dojotools_admintools.yaml
+++ b/packages/zenos_ai/dojotools/dojotools_admintools.yaml
@@ -1018,10 +1018,14 @@ script:
                 non_system_drawers: >-
                   {%- set sys = ['AI_Cabinet_VolumeInfo','_label_index','_context', '_restored_marker','_hammered'] -%}
                   {{- _vars.keys() | reject('in', sys) | reject('match', '^_') | list -}}
-                _vi_raw: "{{ _vars.get('AI_Cabinet_VolumeInfo', {}) }}"
+                #_vi_raw: "{{ _vars.get('AI_Cabinet_VolumeInfo', {}) }}"
+                #_vi_val: >-
+                #  {%- set r = _vi_raw.get('value', {}) if _vi_raw is mapping else {} -%}
+                #  {{ r if r is mapping else (r | from_json if r is string else {}) }}
                 _vi_val: >-
-                  {%- set r = _vi_raw.get('value', {}) if _vi_raw is mapping else {} -%}
-                  {{ r if r is mapping else (r | from_json if r is string else {}) }}
+                  {%- import 'zenos_cabinets.jinja' as CABS -%}
+                  {{- CABS.cabinet_drawer_value(cab, 'AI_Cabinet_VolumeInfo', {}) | from_json() -}}
+
                 cabinet_guid: "{{- _vi_val.get('id', '') | string | trim -}}"
                 cabinet_state_class: >-
                   {%- if not has_volumeinfo and not has_label_index and not has_context
@@ -1200,10 +1204,13 @@ script:
         value_template: "{{- op == 'flip_schema_version' -}}"
       then:
       - variables:
-          _syscab_vars: "{{ state_attr('sensor.zenos_system_cabinet', 'variables') | default({}, true) }}"
-          _syscab_mapped: "{{- _syscab_vars if _syscab_vars is mapping else {} -}}"
-          _csve: "{{ _syscab_mapped.get('cab_schema_version', {}) }}"
-          _csve_mapped: "{{- _csve if _csve is mapping else {} -}}"
+          #_syscab_vars: "{{ state_attr('sensor.zenos_system_cabinet', 'variables') | default({}, true) }}"
+          #_syscab_mapped: "{{- _syscab_vars if _syscab_vars is mapping else {} -}}"
+          #_csve: "{{ _syscab_mapped.get('cab_schema_version', {}) }}"
+          #_csve_mapped: "{{- _csve if _csve is mapping else {} -}}"
+          _csve_mapped: >
+            {%- import 'zenos_cabinets.jinja' as CABS -%}
+            {{- CABS.cabinet_drawer_value('sensor.zenos_system_cabinet', 'cab_schema_version', {}) | from_json() -}}
           _current_v: "{{- _csve_mapped.get('value', 0) | int(0) -}}"
           _new_v: "{{- schema_version | default(none) | int(-1) if schema_version | default(none) is not none else (1 if _current_v == 0 else 0) -}}"
       - event: set_variable_legacy
@@ -1476,11 +1483,14 @@ script:
         alias: Repair / Restamp
         sequence:
         - variables:
-            existing: "{{- state_attr(cabinet_entity,'variables') -}}"
+            #existing: "{{- state_attr(cabinet_entity,'variables') -}}"
+            #existing_guid: >-
+            #  {%- set info = existing.get('AI_Cabinet_VolumeInfo', {}) if existing is mapping else {} -%}
+            #  {%- set _val = info.get('value', {}) if info is mapping else {} -%}
+            #  {%- set _val = _val if _val is mapping else (_val | from_json if _val is string else {}) -%}
             existing_guid: >-
-              {%- set info = existing.get('AI_Cabinet_VolumeInfo', {}) if existing is mapping else {} -%}
-              {%- set _val = info.get('value', {}) if info is mapping else {} -%}
-              {%- set _val = _val if _val is mapping else (_val | from_json if _val is string else {}) -%}
+              {%- import 'zenos_cabinets.jinja' as CABS -%}
+              {%- set _val = CABS.cabinet_drawer_value(cabinet_entity, 'AI_Cabinet_VolumeInfo', {}) | from_json() -%}
               {{- _val.get('id', '') -}}
             guid_changed: "{{- force_new_guid or existing_guid != cabinet_guid -}}"
         - choose:
@@ -2874,12 +2884,16 @@ script:
     # Prompt loader writes directly to syscab via set_variable_zenos_system_cabinet.
     # On any run, if cabinet_ro is missing or false, stamp it. Safe to re-run.
     - variables:
-        _pl_sc_vars: "{{- state_attr('sensor.zenos_system_cabinet', 'variables') | default({}, true) -}}"
-        _pl_sc_mapped: "{{- _pl_sc_vars if _pl_sc_vars is mapping else {} -}}"
-        _pl_vi_raw: "{{- _pl_sc_mapped.get('AI_Cabinet_VolumeInfo', {}) -}}"
-        _pl_vi_mapped: "{{- _pl_vi_raw if _pl_vi_raw is mapping else {} -}}"
-        _pl_vi_val_raw: "{{- _pl_vi_mapped.get('value', _pl_vi_mapped) -}}"
-        _pl_vi_val: "{{- _pl_vi_val_raw if _pl_vi_val_raw is mapping else (_pl_vi_val_raw | from_json if _pl_vi_val_raw is string else {}) -}}"
+        #_pl_sc_vars: "{{- state_attr('sensor.zenos_system_cabinet', 'variables') | default({}, true) -}}"
+        #_pl_sc_mapped: "{{- _pl_sc_vars if _pl_sc_vars is mapping else {} -}}"
+        #_pl_vi_raw: "{{- _pl_sc_mapped.get('AI_Cabinet_VolumeInfo', {}) -}}"
+        #_pl_vi_mapped: "{{- _pl_vi_raw if _pl_vi_raw is mapping else {} -}}"
+        #_pl_vi_val_raw: "{{- _pl_vi_mapped.get('value', _pl_vi_mapped) -}}"
+        #_pl_vi_val: "{{- _pl_vi_val_raw if _pl_vi_val_raw is mapping else (_pl_vi_val_raw | from_json if _pl_vi_val_raw is string else {}) -}}"
+
+        _pl_vi_val: >
+          {%- import 'zenos_cabinets.jinja' as CABS -%}
+          {{- CABS.cabinet_drawer_value('sensor.zenos_system_cabinet', 'AI_Cabinet_VolumeInfo', {}) | from_json() -}}
         _pl_flags: "{{- _pl_vi_val.get('flags', {}) -}}"
         _pl_flags_mapped: "{{- _pl_flags if _pl_flags is mapping else {} -}}"
         _pl_ro_already: "{{- _pl_flags_mapped.get('cabinet_ro', false) == true -}}"

--- a/packages/zenos_ai/dojotools/dojotools_core.yaml
+++ b/packages/zenos_ai/dojotools/dojotools_core.yaml
@@ -369,7 +369,7 @@ script:
                     #  {%- set _v1 = _vi.get('value', _vi) if _vi is mapping else {} -%}
                     #  {{ _v1 if _v1 is mapping else (_v1 | from_json if _v1 is string else {}) }}
                     _vol_info_raw: >-
-                      {%- import 'zenos_cabinets.jinja' as CABS -%}
+                      {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
                       {%- set _val = CABS.cabinet_drawer_value(current_cab, 'AI_Cabinet_VolumeInfo', {}) | from_json() -%}
                     _cab_flags: >-
                       {{ _vol_info_raw.get('flags', {}) }}

--- a/packages/zenos_ai/dojotools/dojotools_core.yaml
+++ b/packages/zenos_ai/dojotools/dojotools_core.yaml
@@ -364,12 +364,15 @@ script:
                         {%- endfor -%}
                       {%- endif -%}
                       {{ ns.stale }}
+                    #_vol_info_raw: >-
+                    #  {%- set _vi = cab_drawers.get('AI_Cabinet_VolumeInfo', {}) -%}
+                    #  {%- set _v1 = _vi.get('value', _vi) if _vi is mapping else {} -%}
+                    #  {{ _v1 if _v1 is mapping else (_v1 | from_json if _v1 is string else {}) }}
                     _vol_info_raw: >-
-                      {%- set _vi = cab_drawers.get('AI_Cabinet_VolumeInfo', {}) -%}
-                      {%- set _v1 = _vi.get('value', _vi) if _vi is mapping else {} -%}
-                      {{ _v1 if _v1 is mapping else (_v1 | from_json if _v1 is string else {}) }}
+                      {%- import 'zenos_cabinets.jinja' as CABS -%}
+                      {%- set _val = CABS.cabinet_drawer_value(current_cab, 'AI_Cabinet_VolumeInfo', {}) | from_json() -%}
                     _cab_flags: >-
-                      {{ _vol_info_raw.get('flags', {}) if _vol_info_raw is mapping else {} }}
+                      {{ _vol_info_raw.get('flags', {}) }}
                     gc_flag_present: >-
                       {{ 'gc_eligible' in _cab_flags }}
                     gc_eligible: >-

--- a/packages/zenos_ai/dojotools/dojotools_filecabinet.yaml
+++ b/packages/zenos_ai/dojotools/dojotools_filecabinet.yaml
@@ -88,21 +88,27 @@ script:
         is_clone: "{{- action_type == 'clone' -}}"
         is_relabel: "{{- action_type == 'relabel' -}}"
         is_write_action: "{{- action_type in ['create','update','delete','move','copy','mount_cabinet','dismount_cabinet','relabel']}}"
-        initial_volume_raw: "{{- state_attr(volume_entity, 'variables') | default({}, true) -}}"
+        #initial_volume_raw: "{{- state_attr(volume_entity, 'variables') | default({}, true) -}}"
+        #initial_volume: >
+        #  {%- if initial_volume_raw is mapping -%}
+        #  {{- initial_volume_raw -}}
+        #  {%- else -%}
+        #  {}
+        #  {%- endif -%}
         initial_volume: >
-          {%- if initial_volume_raw is mapping -%}
-          {{- initial_volume_raw -}}
-          {%- else -%}
-          {}
-          {%- endif -%}
+          {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
+          {%- set essence = CABS.cabinet_variables(volume_entity, 'zenai_essence') | from_json() -%}
         key_exists_initial: "{{- (key != '') and (key in initial_volume) -}}"
-        prewrite_volume_raw: "{{- state_attr(volume_entity, 'variables') | default({}, true) -}}"
+        #prewrite_volume_raw: "{{- state_attr(volume_entity, 'variables') | default({}, true) -}}"
+        #prewrite_volume: >
+        #  {%- if prewrite_volume_raw is mapping -%}
+        #    {{- prewrite_volume_raw -}}
+        #  {%- else -%}
+        #    {}
+        #  {%- endif -%}
         prewrite_volume: >
-          {%- if prewrite_volume_raw is mapping -%}
-            {{- prewrite_volume_raw -}}
-          {%- else -%}
-            {}
-          {%- endif -%}
+          {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
+          {%- set essence = CABS.cabinet_variables(volume_entity, 'zenai_essence') | from_json() -%}
         prettify_json_on_fail: "{{- prettify_json_on_fail | default(false) -}}"
         label_raw: "{{- label_targets | default('') -}}"
         resolved_label_targets: >

--- a/packages/zenos_ai/dojotools/dojotools_filecabinet.yaml
+++ b/packages/zenos_ai/dojotools/dojotools_filecabinet.yaml
@@ -1260,7 +1260,7 @@ script:
             key: "{{- key -}}"
             volume_entity: "{{- volume_entity -}}"
         - wait_template: >
-           {%- set vol = state_attr(volume_entity, 'variables') | default({}, true) -%} 
+            {%- set vol = state_attr(volume_entity, 'variables') | default({}, true) -%} 
             {{- vol is mapping and (key not in vol) -}}
           timeout: 00:00:01
           continue_on_timeout: true

--- a/packages/zenos_ai/dojotools/dojotools_filecabinet.yaml
+++ b/packages/zenos_ai/dojotools/dojotools_filecabinet.yaml
@@ -97,7 +97,6 @@ script:
         #  {%- endif -%}
         initial_volume: >
           {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
-          {%- set essence = CABS.cabinet_variables(volume_entity, 'zenai_essence') | from_json() -%}
         key_exists_initial: "{{- (key != '') and (key in initial_volume) -}}"
         #prewrite_volume_raw: "{{- state_attr(volume_entity, 'variables') | default({}, true) -}}"
         #prewrite_volume: >
@@ -108,7 +107,7 @@ script:
         #  {%- endif -%}
         prewrite_volume: >
           {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
-          {%- set essence = CABS.cabinet_variables(volume_entity, 'zenai_essence') | from_json() -%}
+          {{- CABS.cabinet_variables(volume_entity) | from_json() -}}
         prettify_json_on_fail: "{{- prettify_json_on_fail | default(false) -}}"
         label_raw: "{{- label_targets | default('') -}}"
         resolved_label_targets: >
@@ -1363,7 +1362,7 @@ script:
                         {%- for sub, arr in drawers.items() -%}
                           {%- set al = arr if (arr is iterable and not arr is string) else [arr] -%}
                           {%- if key in al -%}{%- set found = true -%}{%- endif -%}
-                      {%- endfor -%}
+                        {%- endfor -%}
                       {%- elif drawers is iterable and not drawers is string -%}
                         {%- if key in drawers -%}{%- set found = true -%}{%- endif -%}
                       {%- else -%}
@@ -1579,7 +1578,7 @@ script:
             final_response:
               status: "{{- 'success' if write_verified else 'warning' -}}"
               message: >
-                {%- if write_verified -%}  
+                {%- if write_verified -%}
                   Drawer '{{- key -}}' {{ action_type -}}d to '{{- dest_drawer -}}' in '{{- dest_cabinet -}}'.
                 {%- else -%}
                   {{- action_type | title }} completed but write verification failed or delayed.

--- a/packages/zenos_ai/dojotools/dojotools_filecabinet.yaml
+++ b/packages/zenos_ai/dojotools/dojotools_filecabinet.yaml
@@ -1133,7 +1133,7 @@ script:
               {%- set entry = vol.get(key) -%}
               {{- entry is mapping -}}
             {%- else -%}
-              false
+              {{- false -}}
             {%- endif -%}
           timeout: 00:00:05
           continue_on_timeout: true
@@ -1213,7 +1213,7 @@ script:
               {%- set entry = vol.get(key, {}) -%}
               {{- entry.get('value') == new_entry.value -}}
             {%- else -%}
-              false
+              {{- false -}}
             {%- endif -%}
           timeout: 00:00:10
           continue_on_timeout: true

--- a/packages/zenos_ai/dojotools/dojotools_filecabinet.yaml
+++ b/packages/zenos_ai/dojotools/dojotools_filecabinet.yaml
@@ -1326,7 +1326,7 @@ script:
                 volume_entity: "{{- volume_entity -}}"
             - alias: Index prune verification
               wait_template: >
-                {%- import 'zenos_cabinets.jinja' as CABS -%}
+                {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
                 {%- set raw = CABS.cabinet_drawer_value(volume_entity, '_label_index', {}) | from_json() -%}
                 {%- set found = false -%} 
                 {%- if raw is mapping -%}
@@ -1348,7 +1348,7 @@ script:
               continue_on_timeout: true
             - variables:
                 index_pruned_verified: >
-                  {%- import 'zenos_cabinets.jinja' as CABS -%}
+                  {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
                   {%- set raw = CABS.cabinet_drawer_value(volume_entity, '_label_index', {}) | from_json() -%}
                   {%- set found = false -%} 
                   {%- if raw is mapping -%}
@@ -1529,7 +1529,7 @@ script:
                     volume_entity: "{{- volume_entity -}}"
                 - alias: Index prune verification
                   wait_template: >
-                    {%- import 'zenos_cabinets.jinja' as CABS -%}
+                    {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
                     {%- set raw = CABS.cabinet_drawer_value(volume_entity, '_label_index', {}) | from_json() -%}
                     {%- set found = false -%} 
                     {%- if raw is mapping -%}
@@ -1551,7 +1551,7 @@ script:
                   continue_on_timeout: true
                 - variables:
                     index_pruned_verified: >
-                      {%- import 'zenos_cabinets.jinja' as CABS -%}
+                      {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
                       {%- set raw = CABS.cabinet_drawer_value(volume_entity, '_label_index', {}) | from_json() -%}
                       {%- set found = false -%}
                       {%- if raw is mapping -%}
@@ -1744,7 +1744,7 @@ script:
         sequence:
         - variables:
             target_entity_resolved: >
-              {%- import 'zenos_cabinets.jinja' as CABS -%}
+              {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
               {%- set ns = namespace(found='') -%}
               {%- for eid in label_entities('zen_cabinet') | list -%}
                 {%- set vi = CABS.cabinet_drawer_value(eid, 'AI_Cabinet_VolumeInfo', none) | from_json() -%}

--- a/packages/zenos_ai/dojotools/dojotools_filecabinet.yaml
+++ b/packages/zenos_ai/dojotools/dojotools_filecabinet.yaml
@@ -1326,8 +1326,8 @@ script:
                 volume_entity: "{{- volume_entity -}}"
             - alias: Index prune verification
               wait_template: >
-                {%- set vol = state_attr(volume_entity, 'variables') | default({}, true) -%}
-                {%- set raw = vol.get('_label_index', {}).get('value') if vol is mapping else {} -%} 
+                {%- import 'zenos_cabinets.jinja' as CABS -%}
+                {%- set raw = CABS.cabinet_drawer_value(volume_entity, '_label_index', {}) | from_json() -%}
                 {%- set found = false -%} 
                 {%- if raw is mapping -%}
                   {%- for label, drawers in raw.items() -%}
@@ -1348,8 +1348,8 @@ script:
               continue_on_timeout: true
             - variables:
                 index_pruned_verified: >
-                  {%- set vol = state_attr(volume_entity, 'variables') | default({}, true) -%} 
-                  {%- set raw = vol.get('_label_index', {}).get('value') if vol is mapping else {} -%} 
+                  {%- import 'zenos_cabinets.jinja' as CABS -%}
+                  {%- set raw = CABS.cabinet_drawer_value(volume_entity, '_label_index', {}) | from_json() -%}
                   {%- set found = false -%} 
                   {%- if raw is mapping -%}
                     {%- for label, drawers in raw.items() -%}
@@ -1529,8 +1529,8 @@ script:
                     volume_entity: "{{- volume_entity -}}"
                 - alias: Index prune verification
                   wait_template: >
-                    {%- set vol = state_attr(volume_entity, 'variables') | default({}, true) -%} 
-                    {%- set raw = vol.get('_label_index', {}).get('value') if vol is mapping else {} -%} 
+                    {%- import 'zenos_cabinets.jinja' as CABS -%}
+                    {%- set raw = CABS.cabinet_drawer_value(volume_entity, '_label_index', {}) | from_json() -%}
                     {%- set found = false -%} 
                     {%- if raw is mapping -%}
                       {%- for label, drawers in raw.items() -%}
@@ -1551,8 +1551,8 @@ script:
                   continue_on_timeout: true
                 - variables:
                     index_pruned_verified: >
-                      {%- set vol = state_attr(volume_entity, 'variables') | default({}, true) -%}
-                      {%- set raw = vol.get('_label_index', {}).get('value') if vol is mapping else {} -%}
+                      {%- import 'zenos_cabinets.jinja' as CABS -%}
+                      {%- set raw = CABS.cabinet_drawer_value(volume_entity, '_label_index', {}) | from_json() -%}
                       {%- set found = false -%}
                       {%- if raw is mapping -%}
                         {%- for label, drawers in raw.items() -%}
@@ -1744,15 +1744,15 @@ script:
         sequence:
         - variables:
             target_entity_resolved: >
+              {%- import 'zenos_cabinets.jinja' as CABS -%}
               {%- set ns = namespace(found='') -%}
               {%- for eid in label_entities('zen_cabinet') | list -%}
-                {%- set vinfo = state_attr(eid, 'variables') -%}
+                {%- set vi = CABS.cabinet_drawer_value(eid, 'AI_Cabinet_VolumeInfo', none) | from_json() -%}
                 {%- if vinfo is mapping -%}
-                  {%- set _vi_raw = vinfo.get('AI_Cabinet_VolumeInfo', {}) -%}
-                  {%- set vi = _vi_raw.get('value', {}) if _vi_raw is mapping else {} -%}
-                  {%- set vi = vi if vi is mapping else (vi | from_json if vi is string else {}) -%}
-                  {%- if vi is mapping and vi.get('id', '') == target_guid -%}
+                  {#- @todo - ensure we can never compare empty with empty (''=='')-#}
+                  {%- if  vi.get('id', '') == target_guid -%}
                     {%- set ns.found = eid -%}
+                    {%- break -%}
                   {%- endif -%}
                 {%- endif -%}
               {%- endfor -%}

--- a/packages/zenos_ai/dojotools/dojotools_identity.yaml
+++ b/packages/zenos_ai/dojotools/dojotools_identity.yaml
@@ -430,6 +430,7 @@ script:
                   {{- _p -}}
             - variables:
                 _hh_tree: >-
+                  {%- import 'zenos_cabinets.jinja' as CABS -%}
                   {%- set _vi = _hh_vi_raw -%}
                   {%- set _m = _hh_members_raw -%}
                   {%- set _hp = _hh_profile_raw -%}
@@ -441,14 +442,8 @@ script:
                   {%- set _ns = namespace(fams=[]) -%}{# FG-25: namespace required for list mutation inside for-loop #}
                   {%- for fam in _m.get('families', []) -%}
                     {%- set _fc_entity_id = fam.get('entity_id', '') -%}
-                    {%- set _fv = state_attr(_fc_entity_id, 'variables') | default({}, true) -%}
-                    {%- set _fv = _fv if _fv is mapping else {} -%}
-                    {%- set _fvi_raw = _fv.get('AI_Cabinet_VolumeInfo', {}) if _fv is mapping else {} -%}
-                    {%- set _fvi = _fvi_raw.get('value', {}) if _fvi_raw is mapping else {} -%}
-                    {%- set _fvi = _fvi if _fvi is mapping else (_fvi | from_json if _fvi is string else {}) -%}
-                    {%- set _fm = _fv.get('members', {}) -%}
-                    {%- set _fm = _fm if _fm is mapping else (_fm | from_json if _fm is string else {}) -%}
-                    {%- set _fm = _fm.get('value', _fm) if _fm is mapping else {} -%}
+                    {%- set _fvi = CABS.cabinet_drawer_value(_fc_entity_id, 'AI_Cabinet_VolumeInfo', {}) | from_json() -%}
+                    {%- set _fm = CABS.cabinet_drawer_value(_fc_entity_id, 'members', {}) | from_json() -%}
                     {%- set _facls = _fvi.get('acls', {}) | default({}, true) -%}
                     {%- set _facls = _facls if _facls is mapping else {} -%}
                     {%- set _fowners = _facls.get('owner', []) -%}
@@ -457,14 +452,8 @@ script:
                     {%- set _nsf = namespace(subfams=[]) -%}{# FG-25: namespace required for list mutation inside for-loop #}
                     {%- for sf in _fm.get('families', []) -%}
                       {%- set _sf_entity_id = sf.get('entity_id', '') -%}
-                      {%- set _sfv = state_attr(_sf_entity_id, 'variables') | default({}, true) -%}
-                      {%- set _sfv = _sfv if _sfv is mapping else {} -%}
-                      {%- set _sfvi_raw = _sfv.get('AI_Cabinet_VolumeInfo', {}) if _sfv is mapping else {} -%}
-                      {%- set _sfvi = _sfvi_raw.get('value', {}) if _sfvi_raw is mapping else {} -%}
-                      {%- set _sfvi = _sfvi if _sfvi is mapping else (_sfvi | from_json if _sfvi is string else {}) -%}
-                      {%- set _sfm = _sfv.get('members', {}) -%}
-                      {%- set _sfm = _sfm if _sfm is mapping else (_sfm | from_json if _sfm is string else {}) -%}
-                      {%- set _sfm = _sfm.get('value', _sfm) if _sfm is mapping else {} -%}
+                      {%- set _sfvi = CABS.cabinet_drawer_value(_sf_entity_id, 'AI_Cabinet_VolumeInfo', {}) | from_json() -%}
+                      {%- set _sfm = CABS.cabinet_drawer_value(_sf_entity_id, 'members', {}) | from_json() -%}
                       {%- set _nsf.subfams = _nsf.subfams + [{
                         'entity_id': _sf_entity_id,
                         'guid': _sfvi.get('id', _sfvi.get('guid', '')),
@@ -1828,6 +1817,7 @@ script:
                   sequence:
                     - variables:
                         _tree: >-
+                          {%- import 'zenos_cabinets.jinja' as CABS -%}
                           {%- set _vi = _root_vi_raw | from_json if _root_vi_raw is string else _root_vi_raw -%}
                           {%- set _vi = _vi if _vi is mapping else {} -%}
                           {%- set _m = _root_members_raw | from_json if _root_members_raw is string else _root_members_raw -%}
@@ -1845,14 +1835,9 @@ script:
                           {%- set _ns = namespace(fams=[]) -%}{# FG-25: namespace required for list mutation inside for-loop #}
                           {%- for fam in _m.get('families', []) -%}
                             {%- set _fc_entity_id = fam.get('entity_id', '') -%}
-                            {%- set _fv = state_attr(_fc_entity_id, 'variables') | default({}, true) -%}
-                            {%- set _fv = _fv if _fv is mapping else {} -%}
-                            {%- set _fvi_raw = _fv.get('AI_Cabinet_VolumeInfo', {}) if _fv is mapping else {} -%}
-                            {%- set _fvi = _fvi_raw.get('value', {}) if _fvi_raw is mapping else {} -%}
-                            {%- set _fvi = _fvi if _fvi is mapping else (_fvi | from_json if _fvi is string else {}) -%}
-                            {%- set _fm = _fv.get('members', {}) -%}
-                            {%- set _fm = _fm if _fm is mapping else (_fm | from_json if _fm is string else {}) -%}
-                            {%- set _fm = _fm.get('value', _fm) if _fm is mapping else {} -%}
+                            {%- set _fvi = CABS.cabinet_drawer_value(_fc_entity_id, 'AI_Cabinet_VolumeInfo', {}) | from_json() -%}
+                            {%- set _fm = CABS.cabinet_drawer_value(_fc_entity_id, 'members', {}) | from_json() -%}
+
                             {%- set _facls = _fvi.get('acls', {}) | default({}, true) -%}
                             {%- set _facls = _facls if _facls is mapping else {} -%}
                             {%- set _fowners = _facls.get('owner', []) -%}
@@ -1862,14 +1847,9 @@ script:
                             {%- set _nsf = namespace(subfams=[]) -%}{# FG-25: namespace required for list mutation inside for-loop #}
                             {%- for sf in _fm.get('families', []) -%}
                               {%- set _sf_entity_id = sf.get('entity_id', '') -%}
-                              {%- set _sfv = state_attr(_sf_entity_id, 'variables') | default({}, true) -%}
-                              {%- set _sfv = _sfv if _sfv is mapping else {} -%}
-                              {%- set _sfvi_raw = _sfv.get('AI_Cabinet_VolumeInfo', {}) if _sfv is mapping else {} -%}
-                              {%- set _sfvi = _sfvi_raw.get('value', {}) if _sfvi_raw is mapping else {} -%}
-                              {%- set _sfvi = _sfvi if _sfvi is mapping else (_sfvi | from_json if _sfvi is string else {}) -%}
-                              {%- set _sfm = _sfv.get('members', {}) -%}
-                              {%- set _sfm = _sfm if _sfm is mapping else (_sfm | from_json if _sfm is string else {}) -%}
-                              {%- set _sfm = _sfm.get('value', _sfm) if _sfm is mapping else {} -%}
+                              {%- set _sfvi = CABS.cabinet_drawer_value(_sf_entity_id, 'AI_Cabinet_VolumeInfo', {}) | from_json() -%}
+                              {%- set _sfm = CABS.cabinet_drawer_value(_sf_entity_id, 'members', {}) | from_json() -%}
+
                               {%- set _nsf.subfams = _nsf.subfams + [{
                                 'entity_id': _sf_entity_id,
                                 'guid': _sfvi.get('id', _sfvi.get('guid', '')),
@@ -1915,6 +1895,7 @@ script:
                             } | tojson
                           }}
                     - variables:
+                        # @todo - weird - returning a dict where one of the values are JSON encoded strings (i.e. _tree)
                         response: >
                           {{-
                             {
@@ -1947,6 +1928,7 @@ script:
                           {{- _m | tojson -}}
                     - variables:
                         _memberships: >-
+                          {%- import 'zenos_cabinets.jinja' as CABS -%}
                           {%- set _hvi = _hh_vi_raw | from_json if _hh_vi_raw is string else _hh_vi_raw -%}
                           {%- set _hvi = _hvi if _hvi is mapping else {} -%}
                           {%- set _hm = _hh_m_raw | from_json if _hh_m_raw is string else _hh_m_raw -%}
@@ -1969,14 +1951,8 @@ script:
                           {# scan depth-1 families #}
                           {%- for fam in _hm.get('families', []) -%}
                             {%- set _fc_entity_id = fam.get('entity_id', '') -%}
-                            {%- set _fv = state_attr(_fc_entity_id, 'variables') | default({}, true) -%}
-                            {%- set _fv = _fv if _fv is mapping else {} -%}
-                            {%- set _fvi_raw = _fv.get('AI_Cabinet_VolumeInfo', {}) if _fv is mapping else {} -%}
-                            {%- set _fvi = _fvi_raw.get('value', {}) if _fvi_raw is mapping else {} -%}
-                            {%- set _fvi = _fvi if _fvi is mapping else (_fvi | from_json if _fvi is string else {}) -%}
-                            {%- set _fm = _fv.get('members', {}) -%}
-                            {%- set _fm = _fm if _fm is mapping else (_fm | from_json if _fm is string else {}) -%}
-                            {%- set _fm = _fm.get('value', _fm) if _fm is mapping else {} -%}
+                            {%- set _fvi = CABS.cabinet_drawer_value(_fc_entity_id, 'AI_Cabinet_VolumeInfo', {}) | from_json() -%}
+                            {%- set _fm = CABS.cabinet_drawer_value(_fc_entity_id, 'members', {}) | from_json() -%}
                             {%- set _f_users = _fm.get('users', []) + _fm.get('ai_users', []) -%}
                             {%- set _in_fam = _f_users | selectattr('entity_id', 'equalto', _eid) | list | count > 0 -%}
                             {%- if _in_fam -%}
@@ -1992,14 +1968,8 @@ script:
                             {# scan depth-2 sub-families #}
                             {%- for sf in _fm.get('families', []) -%}
                               {%- set _sf_entity_id = sf.get('entity_id', '') -%}
-                              {%- set _sfv = state_attr(_sf_entity_id, 'variables') | default({}, true) -%}
-                              {%- set _sfv = _sfv if _sfv is mapping else {} -%}
-                              {%- set _sfvi_raw = _sfv.get('AI_Cabinet_VolumeInfo', {}) if _sfv is mapping else {} -%}
-                              {%- set _sfvi = _sfvi_raw.get('value', {}) if _sfvi_raw is mapping else {} -%}
-                              {%- set _sfvi = _sfvi if _sfvi is mapping else (_sfvi | from_json if _sfvi is string else {}) -%}
-                              {%- set _sfm = _sfv.get('members', {}) -%}
-                              {%- set _sfm = _sfm if _sfm is mapping else (_sfm | from_json if _sfm is string else {}) -%}
-                              {%- set _sfm = _sfm.get('value', _sfm) if _sfm is mapping else {} -%}
+                              {%- set _sfvi = CABS.cabinet_drawer_value(_sf_entity_id, 'AI_Cabinet_VolumeInfo', {}) | from_json() -%}
+                              {%- set _sfm = CABS.cabinet_drawer_value(_sf_entity_id, 'members', {}) | from_json() -%}
                               {%- set _sf_users = _sfm.get('users', []) + _sfm.get('ai_users', []) -%}
                               {%- set _in_sf = _sf_users | selectattr('entity_id', 'equalto', _eid) | list | count > 0 -%}
                               {%- if _in_sf -%}
@@ -2048,6 +2018,7 @@ script:
                   {{- _m | tojson -}}
             - variables:
                 _check: >-
+                  {%- import 'zenos_cabinets.jinja' as CABS -%}
                   {%- set _m = _container_m_raw | from_json if _container_m_raw is string else _container_m_raw -%}
                   {%- set _m = _m if _m is mapping else {} -%}
                   {%- set _eid = member_entity -%}
@@ -2060,11 +2031,7 @@ script:
                     {%- for fam in _m.get('families', []) -%}
                       {%- if not _found_d2 -%}
                         {%- set _fc_entity_id = fam.get('entity_id', '') -%}
-                        {%- set _fv = state_attr(_fc_entity_id, 'variables') | default({}, true) -%}
-                        {%- set _fv = _fv if _fv is mapping else {} -%}
-                        {%- set _fm = _fv.get('members', {}) -%}
-                        {%- set _fm = _fm if _fm is mapping else (_fm | from_json if _fm is string else {}) -%}
-                        {%- set _fm = _fm.get('value', _fm) if _fm is mapping else {} -%}
+                        {%- set _fm = CABS.cabinet_drawer_value(_fc_entity_id, 'members', {}) | from_json() -%}
                         {%- set _d2_all = _fm.get('users', []) + _fm.get('ai_users', []) -%}
                         {%- set _in_d2 = _d2_all | selectattr('entity_id', 'equalto', _eid) | list | count > 0 -%}
                         {%- if _in_d2 -%}

--- a/packages/zenos_ai/dojotools/dojotools_identity.yaml
+++ b/packages/zenos_ai/dojotools/dojotools_identity.yaml
@@ -421,6 +421,7 @@ script:
                   {%- import 'zenos_cabinets.jinja' as CABS -%}
                   {%- set _m = CABS.cabinet_drawer_value(_hh_cab, 'members', {}) | from_json() -%}
                   {{- _m -}}
+                # @todo - need to modify CABS.cabinet_drawer_value() so it can take a list of keys and return the first one that exists
                 _hh_profile_raw: >-
                   {%- set _v = state_attr(_hh_cab, 'variables') | default({}, true) -%}
                   {%- set _v = _v if _v is mapping else {} -%}
@@ -556,6 +557,7 @@ script:
                   {%- set _vi = _fam_vi_raw | from_json if _fam_vi_raw is string else _fam_vi_raw -%}
                   {%- set _vi = _vi if _vi is mapping else {} -%}
                   {{- _vi.get('id', _vi.get('guid', '')) | string | trim == '' -}}
+                # @todo - need to modify CABS.cabinet_drawer_value() so it can take a list of keys and return the first one that exists
                 _fam_name: >-
                   {%- set _fv = state_attr(family_entity, 'variables') | default({}, true) -%}
                   {%- set _fv = _fv if _fv is mapping else {} -%}
@@ -770,6 +772,7 @@ script:
                   {%- set _vi = _mem_vi_raw | from_json if _mem_vi_raw is string else _mem_vi_raw -%}
                   {%- set _vi = _vi if _vi is mapping else {} -%}
                   {{- _vi.get('id', _vi.get('guid', '')) | string | trim == '' -}}
+                # @todo - need to modify CABS.cabinet_drawer_value() so it can take a list of keys and return the first one that exists
                 _mem_name: >-
                   {%- set _mv = state_attr(member_entity, 'variables') | default({}, true) -%}
                   {%- set _mv = _mv if _mv is mapping else {} -%}
@@ -1073,6 +1076,7 @@ script:
                 _mem_guid: >-
                   {%- set _vi = _mem_vi_raw | from_json if _mem_vi_raw is string else _mem_vi_raw -%}
                   {{- (_vi if _vi is mapping else {}).get('id', (_vi if _vi is mapping else {}).get('guid', '')) -}}
+                # @todo - need to modify CABS.cabinet_drawer_value() so it can take a list of keys and return the first one that exists
                 _mem_name: >-
                   {%- set _mv = state_attr(member_entity, 'variables') | default({}, true) -%}
                   {%- set _mv = _mv if _mv is mapping else {} -%}
@@ -1177,6 +1181,7 @@ script:
                   {%- if _existing != '' -%}{{- _existing -}}{%- else -%}
                   {{- '%04x%04x-%04x-%04x-%04x-%04x%04x%04x' | format( range(0, 65536) | random, range(0, 65536) | random, range(0, 65536) | random, range(0, 65536) | random, range(0, 65536) | random, range(0, 65536) | random, range(0, 65536) | random, range(0, 65536) | random) -}}
                   {%- endif -%}
+                # @todo - need to modify CABS.cabinet_drawer_value() so it can take a list of keys and return the first one that exists
                 _mem_name: >-
                   {%- set _mv = state_attr(member_entity, 'variables') | default({}, true) -%}
                   {%- set _mv = _mv if _mv is mapping else {} -%}
@@ -1194,6 +1199,7 @@ script:
                   {%- set _vi = _fam_vi_raw | from_json if _fam_vi_raw is string else _fam_vi_raw -%}
                   {%- set _vi = _vi if _vi is mapping else {} -%}
                   {{- _vi.get('id', _vi.get('guid', '')) -}}
+                # @todo - need to modify CABS.cabinet_drawer_value() so it can take a list of keys and return the first one that exists
                 _fam_name: >-
                   {%- set _fv = state_attr(family_entity, 'variables') | default({}, true) -%}
                   {%- set _fv = _fv if _fv is mapping else {} -%}
@@ -1362,6 +1368,7 @@ script:
                   {%- set _vi = _fam_vi_raw | from_json if _fam_vi_raw is string else _fam_vi_raw -%}
                   {%- set _vi = _vi if _vi is mapping else {} -%}
                   {{- _vi.get('id', _vi.get('guid', '')) -}}
+                # @todo - need to modify CABS.cabinet_drawer_value() so it can take a list of keys and return the first one that exists
                 _fam_name: >-
                   {%- set _fv = state_attr(family_entity, 'variables') | default({}, true) -%}
                   {%- set _fv = _fv if _fv is mapping else {} -%}
@@ -1376,6 +1383,7 @@ script:
                   {%- set _vi = _mem_vi_raw | from_json if _mem_vi_raw is string else _mem_vi_raw -%}
                   {%- set _vi = _vi if _vi is mapping else {} -%}
                   {{- _vi.get('id', _vi.get('guid', '')) -}}
+                # @todo - need to modify CABS.cabinet_drawer_value() so it can take a list of keys and return the first one that exists
                 _mem_name: >-
                   {%- set _mv = state_attr(member_entity, 'variables') | default({}, true) -%}
                   {%- set _mv = _mv if _mv is mapping else {} -%}
@@ -1792,6 +1800,7 @@ script:
                   {%- import 'zenos_cabinets.jinja' as CABS -%}
                   {%- set _m = CABS.cabinet_drawer_value(_root_entity, 'members', {}) | from_json() -%}
                   {{- _m | tojson -}}
+                # @todo - need to modify CABS.cabinet_drawer_value() so it can take a list of keys and return the first one that exists
                 _root_profile_raw: >-
                   {%- set _v = state_attr(_root_entity, 'variables') | default({}, true) -%}
                   {%- set _v = _v if _v is mapping else {} -%}

--- a/packages/zenos_ai/dojotools/dojotools_identity.yaml
+++ b/packages/zenos_ai/dojotools/dojotools_identity.yaml
@@ -414,11 +414,11 @@ script:
             # — build household tree to depth 2 alongside flat roster —
             - variables:
                 _hh_vi_raw: >-
-                  {%- import 'zenos_cabinets.jinja' as CABS -%}
+                  {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
                   {%- set _vi = CABS.cabinet_drawer_value(_hh_cab, 'AI_Cabinet_VolumeInfo', {}) | from_json() -%}
                   {{- _vi -}}
                 _hh_members_raw: >-
-                  {%- import 'zenos_cabinets.jinja' as CABS -%}
+                  {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
                   {%- set _m = CABS.cabinet_drawer_value(_hh_cab, 'members', {}) | from_json() -%}
                   {{- _m -}}
                 # @todo - need to modify CABS.cabinet_drawer_value() so it can take a list of keys and return the first one that exists
@@ -431,7 +431,7 @@ script:
                   {{- _p -}}
             - variables:
                 _hh_tree: >-
-                  {%- import 'zenos_cabinets.jinja' as CABS -%}
+                  {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
                   {%- set _vi = _hh_vi_raw -%}
                   {%- set _m = _hh_members_raw -%}
                   {%- set _hp = _hh_profile_raw -%}
@@ -535,11 +535,11 @@ script:
                   response_variable: response
             - variables:
                 _fam_vi_raw: >-
-                  {%- import 'zenos_cabinets.jinja' as CABS -%}
+                  {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
                   {%- set _vi = CABS.cabinet_drawer_value(family_entity, 'AI_Cabinet_VolumeInfo', {}) | from_json() -%}
                   {{- _vi | tojson -}}
                 _hh_members_raw: >-
-                  {%- import 'zenos_cabinets.jinja' as CABS -%}
+                  {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
                   {%- set _vi = CABS.cabinet_drawer_value(_hh_cab, 'members', {}) | from_json() -%}
                   {{- _m | tojson -}}
             - variables:
@@ -680,7 +680,7 @@ script:
                   response_variable: response
             - variables:
                 _hh_members_raw: >-
-                  {%- import 'zenos_cabinets.jinja' as CABS -%}
+                  {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
                   {%- set _m = CABS.cabinet_drawer_value(_hh_cab, 'members', {}) | from_json() -%}
                   {{- _m | tojson -}}
             - variables:
@@ -743,15 +743,15 @@ script:
                   response_variable: response
             - variables:
                 _hh_vi_raw: >-
-                  {%- import 'zenos_cabinets.jinja' as CABS -%}
+                  {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
                   {%- set _vi = CABS.cabinet_drawer_value(_hh_cab, 'AI_Cabinet_VolumeInfo', {}) | from_json() -%}
                   {{- _vi | tojson -}}
                 _hh_members_raw: >-
-                  {%- import 'zenos_cabinets.jinja' as CABS -%}
+                  {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
                   {%- set _m = CABS.cabinet_drawer_value(_hh_cab, 'members', {}) | from_json() -%}
                   {{- _m | tojson -}}
                 _mem_vi_raw: >-
-                  {%- import 'zenos_cabinets.jinja' as CABS -%}
+                  {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
                   {%- set _vi = CABS.cabinet_drawer_value(member_entity, 'AI_Cabinet_VolumeInfo', {}) | from_json() -%}
                   {{- _vi | tojson -}}
             - variables:
@@ -970,11 +970,11 @@ script:
             - variables:
                 _list_key: "{{- 'ai_users' if member_type == 'ai_user' else 'users' -}}"
                 _hh_members_raw: >-
-                  {%- import 'zenos_cabinets.jinja' as CABS -%}
+                  {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
                   {%- set _m = CABS.cabinet_drawer_value(_hh_cab, 'members', {}) | from_json() -%}
                   {{- _m | tojson -}}
                 _hh_vi_raw: >-
-                  {%- import 'zenos_cabinets.jinja' as CABS -%}
+                  {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
                   {%- set _vi = CABS.cabinet_drawer_value(_hh_cab, 'AI_Cabinet_VolumeInfo', {}) | from_json() -%}
                   {{- _vi | tojson -}}
             - variables:
@@ -1065,11 +1065,11 @@ script:
                   response_variable: response
             - variables:
                 _hh_vi_raw: >-
-                  {%- import 'zenos_cabinets.jinja' as CABS -%}
+                  {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
                   {%- set _vi = CABS.cabinet_drawer_value(_target_cab, 'AI_Cabinet_VolumeInfo', {}) | from_json() -%}
                   {{- _vi | tojson -}}
                 _mem_vi_raw: >-
-                  {%- import 'zenos_cabinets.jinja' as CABS -%}
+                  {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
                   {%- set _vi = CABS.cabinet_drawer_value(member_entity, 'AI_Cabinet_VolumeInfo', {}) | from_json() -%}
                   {{- _vi | tojson -}}
             - variables:
@@ -1162,15 +1162,15 @@ script:
                   response_variable: response
             - variables:
                 _fam_members_raw: >-
-                  {%- import 'zenos_cabinets.jinja' as CABS -%}
+                  {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
                   {%- set _m = CABS.cabinet_drawer_value(family_entity, 'members', {}) | from_json() -%}
                   {{- _m | tojson -}}
                 _mem_vi_raw: >-
-                  {%- import 'zenos_cabinets.jinja' as CABS -%}
+                  {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
                   {%- set _vi = CABS.cabinet_drawer_value(member_entity, 'AI_Cabinet_VolumeInfo', {}) | from_json() -%}
                   {{- _vi | tojson -}}
                 _fam_vi_raw: >-
-                  {%- import 'zenos_cabinets.jinja' as CABS -%}
+                  {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
                   {%- set _vi = CABS.cabinet_drawer_value(family_entity, 'AI_Cabinet_VolumeInfo', {}) | from_json() -%}
                   {{- _vi | tojson -}}
             - variables:
@@ -1352,15 +1352,15 @@ script:
                   response_variable: response
             - variables:
                 _fam_members_raw: >-
-                  {%- import 'zenos_cabinets.jinja' as CABS -%}
+                  {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
                   {%- set _m = CABS.cabinet_drawer_value(family_entity, 'members', {}) | from_json() -%}
                   {{- _m | tojson -}}
                 _mem_vi_raw: >-
-                  {%- import 'zenos_cabinets.jinja' as CABS -%}
+                  {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
                   {%- set _vi = CABS.cabinet_drawer_value(member_entity, 'AI_Cabinet_VolumeInfo', {}) | from_json() -%}
                   {{- _vi | tojson -}}
                 _fam_vi_raw: >-
-                  {%- import 'zenos_cabinets.jinja' as CABS -%}
+                  {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
                   {%- set _vi = CABS.cabinet_drawer_value(family_entity, 'AI_Cabinet_VolumeInfo', {}) | from_json() -%}
                   {{- _vi | tojson -}}
             - variables:
@@ -1406,7 +1406,7 @@ script:
                   {%- set _vi = _vi if _vi is mapping else {} -%}
                   {{- _vi.get('default_family_guid', '') == _fam_guid -}}
                 _fam_vi_raw2: >-
-                  {%- import 'zenos_cabinets.jinja' as CABS -%}
+                  {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
                   {%- set _vi = CABS.cabinet_drawer_value(family_entity, 'AI_Cabinet_VolumeInfo', {}) | from_json() -%}
                   {{- _vi | tojson -}}
                 _principal_warning: >-
@@ -1522,11 +1522,11 @@ script:
                   response_variable: response
             - variables:
                 _a_vi_raw: >-
-                  {%- import 'zenos_cabinets.jinja' as CABS -%}
+                  {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
                   {%- set _vi = CABS.cabinet_drawer_value(member_entity, 'AI_Cabinet_VolumeInfo', {}) | from_json() -%}
                   {{- _vi | tojson -}}
                 _b_vi_raw: >-
-                  {%- import 'zenos_cabinets.jinja' as CABS -%}
+                  {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
                   {%- set _vi = CABS.cabinet_drawer_value(ai_entity, 'AI_Cabinet_VolumeInfo', {}) | from_json() -%}
                   {{- _vi | tojson -}}
             - variables:
@@ -1641,11 +1641,11 @@ script:
                   response_variable: response
             - variables:
                 _a_vi_raw: >-
-                  {%- import 'zenos_cabinets.jinja' as CABS -%}
+                  {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
                   {%- set _vi = CABS.cabinet_drawer_value(member_entity, 'AI_Cabinet_VolumeInfo', {}) | from_json() -%}
                   {{- _vi | tojson -}}
                 _b_vi_raw: >-
-                  {%- import 'zenos_cabinets.jinja' as CABS -%}
+                  {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
                   {%- set _vi = CABS.cabinet_drawer_value(ai_entity, 'AI_Cabinet_VolumeInfo', {}) | from_json() -%}
                   {{- _vi | tojson -}}
             - variables:
@@ -1734,11 +1734,11 @@ script:
                   response_variable: response
             - variables:
                 _mem_vi_raw: >-
-                  {%- import 'zenos_cabinets.jinja' as CABS -%}
+                  {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
                   {%- set _vi = CABS.cabinet_drawer_value(member_entity, 'AI_Cabinet_VolumeInfo', {}) | from_json() -%}
                   {{- _vi | tojson -}}
                 _fam_vi_raw: >-
-                  {%- import 'zenos_cabinets.jinja' as CABS -%}
+                  {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
                   {%- set _vi = CABS.cabinet_drawer_value(family_entity, 'AI_Cabinet_VolumeInfo', {}) | from_json() -%}
                   {{- _vi | tojson -}}
             - variables:
@@ -1793,11 +1793,11 @@ script:
                 _hh_default: "{{- _hh_target -}}"
             - variables:
                 _root_vi_raw: >-
-                  {%- import 'zenos_cabinets.jinja' as CABS -%}
+                  {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
                   {%- set _vi = CABS.cabinet_drawer_value(_root_entity, 'AI_Cabinet_VolumeInfo', {}) | from_json() -%}
                   {{- _vi | tojson -}}
                 _root_members_raw: >-
-                  {%- import 'zenos_cabinets.jinja' as CABS -%}
+                  {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
                   {%- set _m = CABS.cabinet_drawer_value(_root_entity, 'members', {}) | from_json() -%}
                   {{- _m | tojson -}}
                 # @todo - need to modify CABS.cabinet_drawer_value() so it can take a list of keys and return the first one that exists
@@ -1826,7 +1826,7 @@ script:
                   sequence:
                     - variables:
                         _tree: >-
-                          {%- import 'zenos_cabinets.jinja' as CABS -%}
+                          {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
                           {%- set _vi = _root_vi_raw | from_json if _root_vi_raw is string else _root_vi_raw -%}
                           {%- set _vi = _vi if _vi is mapping else {} -%}
                           {%- set _m = _root_members_raw | from_json if _root_members_raw is string else _root_members_raw -%}
@@ -1928,16 +1928,16 @@ script:
                         _target_eid: "{{- _root_entity -}}"
                     - variables:
                         _hh_vi_raw: >-
-                          {%- import 'zenos_cabinets.jinja' as CABS -%}
+                          {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
                           {%- set _vi = CABS.cabinet_drawer_value(_lookup_root, 'AI_Cabinet_VolumeInfo', {}) | from_json() -%}
                           {{- _vi | tojson -}}
                         _hh_m_raw: >-
-                          {%- import 'zenos_cabinets.jinja' as CABS -%}
+                          {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
                           {%- set _m = CABS.cabinet_drawer_value(_lookup_root, 'members', {}) | from_json() -%}
                           {{- _m | tojson -}}
                     - variables:
                         _memberships: >-
-                          {%- import 'zenos_cabinets.jinja' as CABS -%}
+                          {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
                           {%- set _hvi = _hh_vi_raw | from_json if _hh_vi_raw is string else _hh_vi_raw -%}
                           {%- set _hvi = _hvi if _hvi is mapping else {} -%}
                           {%- set _hm = _hh_m_raw | from_json if _hh_m_raw is string else _hh_m_raw -%}
@@ -2022,12 +2022,12 @@ script:
                   response_variable: response
             - variables:
                 _container_m_raw: >-
-                  {%- import 'zenos_cabinets.jinja' as CABS -%}
+                  {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
                   {%- set _m = CABS.cabinet_drawer_value(family_entity, 'members', {}) | from_json() -%}
                   {{- _m | tojson -}}
             - variables:
                 _check: >-
-                  {%- import 'zenos_cabinets.jinja' as CABS -%}
+                  {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
                   {%- set _m = _container_m_raw | from_json if _container_m_raw is string else _container_m_raw -%}
                   {%- set _m = _m if _m is mapping else {} -%}
                   {%- set _eid = member_entity -%}

--- a/packages/zenos_ai/dojotools/dojotools_identity.yaml
+++ b/packages/zenos_ai/dojotools/dojotools_identity.yaml
@@ -440,7 +440,8 @@ script:
                   {%- set _prime = _partners | selectattr('role', 'defined') | selectattr('role', 'equalto', 'prime') | list -%}
                   {%- set _ns = namespace(fams=[]) -%}{# FG-25: namespace required for list mutation inside for-loop #}
                   {%- for fam in _m.get('families', []) -%}
-                    {%- set _fv = state_attr(fam.get('entity_id', ''), 'variables') | default({}, true) -%}
+                    {%- set _fc_entity_id = fam.get('entity_id', '') -%}
+                    {%- set _fv = state_attr(_fc_entity_id, 'variables') | default({}, true) -%}
                     {%- set _fv = _fv if _fv is mapping else {} -%}
                     {%- set _fvi_raw = _fv.get('AI_Cabinet_VolumeInfo', {}) if _fv is mapping else {} -%}
                     {%- set _fvi = _fvi_raw.get('value', {}) if _fvi_raw is mapping else {} -%}
@@ -455,7 +456,8 @@ script:
                     {%- set _fprime = _fpartners | selectattr('role', 'defined') | selectattr('role', 'equalto', 'prime') | list -%}
                     {%- set _nsf = namespace(subfams=[]) -%}{# FG-25: namespace required for list mutation inside for-loop #}
                     {%- for sf in _fm.get('families', []) -%}
-                      {%- set _sfv = state_attr(sf.get('entity_id', ''), 'variables') | default({}, true) -%}
+                      {%- set _sf_entity_id = sf.get('entity_id', '') -%}
+                      {%- set _sfv = state_attr(_sf_entity_id, 'variables') | default({}, true) -%}
                       {%- set _sfv = _sfv if _sfv is mapping else {} -%}
                       {%- set _sfvi_raw = _sfv.get('AI_Cabinet_VolumeInfo', {}) if _sfv is mapping else {} -%}
                       {%- set _sfvi = _sfvi_raw.get('value', {}) if _sfvi_raw is mapping else {} -%}
@@ -464,17 +466,17 @@ script:
                       {%- set _sfm = _sfm if _sfm is mapping else (_sfm | from_json if _sfm is string else {}) -%}
                       {%- set _sfm = _sfm.get('value', _sfm) if _sfm is mapping else {} -%}
                       {%- set _nsf.subfams = _nsf.subfams + [{
-                        'entity_id': sf.get('entity_id', ''),
+                        'entity_id': _sf_entity_id,
                         'guid': _sfvi.get('id', _sfvi.get('guid', '')),
-                        'name': sf.get('name', _sfvi.get('friendly_name', _sfvi.get('name', sf.get('entity_id', '')))),
+                        'name': sf.get('name', _sfvi.get('friendly_name', _sfvi.get('name', _sf_entity_id))),
                         'depth': 2,
                         'members': {'users': _sfm.get('users', []), 'ai_users': _sfm.get('ai_users', [])}
                       }] -%}
                     {%- endfor -%}
                     {%- set _ns.fams = _ns.fams + [{
-                      'entity_id': fam.get('entity_id', ''),
+                      'entity_id': _fc_entity_id,
                       'guid': _fvi.get('id', _fvi.get('guid', '')),
-                      'name': fam.get('name', _fvi.get('friendly_name', _fvi.get('name', fam.get('entity_id', '')))),
+                      'name': fam.get('name', _fvi.get('friendly_name', _fvi.get('name', _fc_entity_id))),
                       'depth': fam.get('depth', 1),
                       'principals': {'hoh': _fowners[0] if _fowners | count > 0 else none, 'prime': _fprime[0] if _fprime | count > 0 else none},
                       'members': {'users': _fm.get('users', []), 'ai_users': _fm.get('ai_users', []), 'families': _nsf.subfams}
@@ -1842,7 +1844,8 @@ script:
                           {# depth-1 families with their members #}
                           {%- set _ns = namespace(fams=[]) -%}{# FG-25: namespace required for list mutation inside for-loop #}
                           {%- for fam in _m.get('families', []) -%}
-                            {%- set _fv = state_attr(fam.get('entity_id', ''), 'variables') | default({}, true) -%}
+                            {%- set _fc_entity_id = fam.get('entity_id', '') -%}
+                            {%- set _fv = state_attr(_fc_entity_id, 'variables') | default({}, true) -%}
                             {%- set _fv = _fv if _fv is mapping else {} -%}
                             {%- set _fvi_raw = _fv.get('AI_Cabinet_VolumeInfo', {}) if _fv is mapping else {} -%}
                             {%- set _fvi = _fvi_raw.get('value', {}) if _fvi_raw is mapping else {} -%}
@@ -1858,7 +1861,8 @@ script:
                             {# depth-2 sub-families (members only, no further recursion) #}
                             {%- set _nsf = namespace(subfams=[]) -%}{# FG-25: namespace required for list mutation inside for-loop #}
                             {%- for sf in _fm.get('families', []) -%}
-                              {%- set _sfv = state_attr(sf.get('entity_id', ''), 'variables') | default({}, true) -%}
+                              {%- set _sf_entity_id = sf.get('entity_id', '') -%}
+                              {%- set _sfv = state_attr(_sf_entity_id, 'variables') | default({}, true) -%}
                               {%- set _sfv = _sfv if _sfv is mapping else {} -%}
                               {%- set _sfvi_raw = _sfv.get('AI_Cabinet_VolumeInfo', {}) if _sfv is mapping else {} -%}
                               {%- set _sfvi = _sfvi_raw.get('value', {}) if _sfvi_raw is mapping else {} -%}
@@ -1867,9 +1871,9 @@ script:
                               {%- set _sfm = _sfm if _sfm is mapping else (_sfm | from_json if _sfm is string else {}) -%}
                               {%- set _sfm = _sfm.get('value', _sfm) if _sfm is mapping else {} -%}
                               {%- set _nsf.subfams = _nsf.subfams + [{
-                                'entity_id': sf.get('entity_id', ''),
+                                'entity_id': _sf_entity_id,
                                 'guid': _sfvi.get('id', _sfvi.get('guid', '')),
-                                'name': sf.get('name', _sfvi.get('friendly_name', _sfvi.get('name', sf.get('entity_id', '')))),
+                                'name': sf.get('name', _sfvi.get('friendly_name', _sfvi.get('name', _sf_entity_id))),
                                 'depth': 2,
                                 'members': {
                                   'users': _sfm.get('users', []),
@@ -1878,9 +1882,9 @@ script:
                               }] -%}
                             {%- endfor -%}
                             {%- set _ns.fams = _ns.fams + [{
-                              'entity_id': fam.get('entity_id', ''),
+                              'entity_id': _fc_entity_id,
                               'guid': _fvi.get('id', _fvi.get('guid', '')),
-                              'name': fam.get('name', _fvi.get('friendly_name', _fvi.get('name', fam.get('entity_id', '')))),
+                              'name': fam.get('name', _fvi.get('friendly_name', _fvi.get('name', _fc_entity_id))),
                               'depth': fam.get('depth', 1),
                               'principals': {
                                 'hoh': _fowners[0] if _fowners | count > 0 else none,
@@ -1964,7 +1968,8 @@ script:
                           {%- endif -%}
                           {# scan depth-1 families #}
                           {%- for fam in _hm.get('families', []) -%}
-                            {%- set _fv = state_attr(fam.get('entity_id', ''), 'variables') | default({}, true) -%}
+                            {%- set _fc_entity_id = fam.get('entity_id', '') -%}
+                            {%- set _fv = state_attr(_fc_entity_id, 'variables') | default({}, true) -%}
                             {%- set _fv = _fv if _fv is mapping else {} -%}
                             {%- set _fvi_raw = _fv.get('AI_Cabinet_VolumeInfo', {}) if _fv is mapping else {} -%}
                             {%- set _fvi = _fvi_raw.get('value', {}) if _fvi_raw is mapping else {} -%}
@@ -1982,11 +1987,12 @@ script:
                               {%- set _is_fhoh = _fown | selectattr('entity_id', 'equalto', _eid) | list | count > 0 -%}
                               {%- set _is_fprime = _fprt | selectattr('entity_id', 'equalto', _eid) | selectattr('role', 'defined') | selectattr('role', 'equalto', 'prime') | list | count > 0 -%}
                               {%- set _frole = 'hoh' if _is_fhoh else ('prime' if _is_fprime else 'member') -%}
-                              {%- set _groups = _groups + [{'container': fam.get('entity_id', ''), 'container_type': 'family', 'guid': _fvi.get('id', _fvi.get('guid', '')), 'name': fam.get('name', _fvi.get('friendly_name', _fvi.get('name', fam.get('entity_id', '')))), 'depth': 1, 'role': _frole}] -%}
+                              {%- set _groups = _groups + [{'container': _fc_entity_id, 'container_type': 'family', 'guid': _fvi.get('id', _fvi.get('guid', '')), 'name': fam.get('name', _fvi.get('friendly_name', _fvi.get('name', _fc_entity_id))), 'depth': 1, 'role': _frole}] -%}
                             {%- endif -%}
                             {# scan depth-2 sub-families #}
                             {%- for sf in _fm.get('families', []) -%}
-                              {%- set _sfv = state_attr(sf.get('entity_id', ''), 'variables') | default({}, true) -%}
+                              {%- set _sf_entity_id = sf.get('entity_id', '') -%}
+                              {%- set _sfv = state_attr(_sf_entity_id, 'variables') | default({}, true) -%}
                               {%- set _sfv = _sfv if _sfv is mapping else {} -%}
                               {%- set _sfvi_raw = _sfv.get('AI_Cabinet_VolumeInfo', {}) if _sfv is mapping else {} -%}
                               {%- set _sfvi = _sfvi_raw.get('value', {}) if _sfvi_raw is mapping else {} -%}
@@ -1997,7 +2003,7 @@ script:
                               {%- set _sf_users = _sfm.get('users', []) + _sfm.get('ai_users', []) -%}
                               {%- set _in_sf = _sf_users | selectattr('entity_id', 'equalto', _eid) | list | count > 0 -%}
                               {%- if _in_sf -%}
-                                {%- set _groups = _groups + [{'container': sf.get('entity_id', ''), 'container_type': 'family', 'guid': _sfvi.get('id', _sfvi.get('guid', '')), 'name': sf.get('name', _sfvi.get('friendly_name', _sfvi.get('name', sf.get('entity_id', '')))), 'depth': 2, 'role': 'member'}] -%}
+                                {%- set _groups = _groups + [{'container': _sf_entity_id, 'container_type': 'family', 'guid': _sfvi.get('id', _sfvi.get('guid', '')), 'name': sf.get('name', _sfvi.get('friendly_name', _sfvi.get('name', _sf_entity_id))), 'depth': 2, 'role': 'member'}] -%}
                               {%- endif -%}
                             {%- endfor -%}
                           {%- endfor -%}
@@ -2053,7 +2059,8 @@ script:
                     {%- set _found_d2 = false -%}
                     {%- for fam in _m.get('families', []) -%}
                       {%- if not _found_d2 -%}
-                        {%- set _fv = state_attr(fam.get('entity_id', ''), 'variables') | default({}, true) -%}
+                        {%- set _fc_entity_id = fam.get('entity_id', '') -%}
+                        {%- set _fv = state_attr(_fc_entity_id, 'variables') | default({}, true) -%}
                         {%- set _fv = _fv if _fv is mapping else {} -%}
                         {%- set _fm = _fv.get('members', {}) -%}
                         {%- set _fm = _fm if _fm is mapping else (_fm | from_json if _fm is string else {}) -%}

--- a/packages/zenos_ai/dojotools/dojotools_identity.yaml
+++ b/packages/zenos_ai/dojotools/dojotools_identity.yaml
@@ -414,34 +414,25 @@ script:
             # — build household tree to depth 2 alongside flat roster —
             - variables:
                 _hh_vi_raw: >-
-                  {%- set _v = state_attr(_hh_cab, 'variables') | default({}, true) -%}
-                  {%- set _v = _v if _v is mapping else {} -%}
-                  {%- set _vi = _v.get('AI_Cabinet_VolumeInfo', _v) -%}
-                  {%- set _vi = _vi.get('value', _vi) if _vi is mapping else {} -%}
-                  {%- set _vi = _vi | from_json if _vi is string else _vi -%}
-                  {{- _vi | tojson -}}
+                  {%- import 'zenos_cabinets.jinja' as CABS -%}
+                  {%- set _vi = CABS.cabinet_drawer_value(_hh_cab, 'AI_Cabinet_VolumeInfo', {}) | from_json() -%}
+                  {{- _vi -}}
                 _hh_members_raw: >-
-                  {%- set _v = state_attr(_hh_cab, 'variables') | default({}, true) -%}
-                  {%- set _v = _v if _v is mapping else {} -%}
-                  {%- set _m = _v.get('members', {}) -%}
-                  {%- set _m = _m if _m is mapping else (_m | from_json if _m is string else {}) -%}
-                  {%- set _m = _m.get('value', _m) if _m is mapping else {} -%}
-                  {{- _m | tojson -}}
+                  {%- import 'zenos_cabinets.jinja' as CABS -%}
+                  {%- set _m = CABS.cabinet_drawer_value(_hh_cab, 'members', {}) | from_json() -%}
+                  {{- _m -}}
                 _hh_profile_raw: >-
                   {%- set _v = state_attr(_hh_cab, 'variables') | default({}, true) -%}
                   {%- set _v = _v if _v is mapping else {} -%}
                   {%- set _p = _v.get('_household_profile', _v.get('household_profile', {})) -%}
                   {%- set _p = _p.get('value', _p) if _p is mapping else {} -%}
                   {%- set _p = _p | from_json if _p is string else _p -%}
-                  {{- _p | tojson -}}
+                  {{- _p -}}
             - variables:
                 _hh_tree: >-
-                  {%- set _vi = _hh_vi_raw | from_json if _hh_vi_raw is string else _hh_vi_raw -%}
-                  {%- set _vi = _vi if _vi is mapping else {} -%}
-                  {%- set _m = _hh_members_raw | from_json if _hh_members_raw is string else _hh_members_raw -%}
-                  {%- set _m = _m if _m is mapping else {} -%}
-                  {%- set _hp = _hh_profile_raw | from_json if _hh_profile_raw is string else _hh_profile_raw -%}
-                  {%- set _hp = _hp if _hp is mapping else {} -%}
+                  {%- set _vi = _hh_vi_raw -%}
+                  {%- set _m = _hh_members_raw -%}
+                  {%- set _hp = _hh_profile_raw -%}
                   {%- set _acls = _vi.get('acls', {}) -%}
                   {%- set _acls = _acls if _acls is mapping else {} -%}
                   {%- set _owners = _acls.get('owner', []) -%}
@@ -552,18 +543,12 @@ script:
                   response_variable: response
             - variables:
                 _fam_vi_raw: >-
-                  {%- set _v = state_attr(family_entity, 'variables') | default({}, true) -%}
-                  {%- set _v = _v if _v is mapping else {} -%}
-                  {%- set _vi = _v.get('AI_Cabinet_VolumeInfo', _v) -%}
-                  {%- set _vi = _vi.get('value', _vi) if _vi is mapping else {} -%}
-                  {%- set _vi = _vi | from_json if _vi is string else _vi -%}
+                  {%- import 'zenos_cabinets.jinja' as CABS -%}
+                  {%- set _vi = CABS.cabinet_drawer_value(family_entity, 'AI_Cabinet_VolumeInfo', {}) | from_json() -%}
                   {{- _vi | tojson -}}
                 _hh_members_raw: >-
-                  {%- set _v = state_attr(_hh_cab, 'variables') | default({}, true) -%}
-                  {%- set _v = _v if _v is mapping else {} -%}
-                  {%- set _m = _v.get('members', {}) -%}
-                  {%- set _m = _m if _m is mapping else (_m | from_json if _m is string else {}) -%}
-                  {%- set _m = _m.get('value', _m) if _m is mapping else {} -%}
+                  {%- import 'zenos_cabinets.jinja' as CABS -%}
+                  {%- set _vi = CABS.cabinet_drawer_value(_hh_cab, 'members', {}) | from_json() -%}
                   {{- _m | tojson -}}
             - variables:
                 _fam_vi: "{{- _fam_vi_raw | from_json if _fam_vi_raw is string else _fam_vi_raw -}}"
@@ -702,11 +687,8 @@ script:
                   response_variable: response
             - variables:
                 _hh_members_raw: >-
-                  {%- set _v = state_attr(_hh_cab, 'variables') | default({}, true) -%}
-                  {%- set _v = _v if _v is mapping else {} -%}
-                  {%- set _m = _v.get('members', {}) -%}
-                  {%- set _m = _m if _m is mapping else (_m | from_json if _m is string else {}) -%}
-                  {%- set _m = _m.get('value', _m) if _m is mapping else {} -%}
+                  {%- import 'zenos_cabinets.jinja' as CABS -%}
+                  {%- set _m = CABS.cabinet_drawer_value(_hh_cab, 'members', {}) | from_json() -%}
                   {{- _m | tojson -}}
             - variables:
                 _updated_members: >-
@@ -768,25 +750,16 @@ script:
                   response_variable: response
             - variables:
                 _hh_vi_raw: >-
-                  {%- set _v = state_attr(_hh_cab, 'variables') | default({}, true) -%}
-                  {%- set _v = _v if _v is mapping else {} -%}
-                  {%- set _vi = _v.get('AI_Cabinet_VolumeInfo', _v) -%}
-                  {%- set _vi = _vi.get('value', _vi) if _vi is mapping else {} -%}
-                  {%- set _vi = _vi | from_json if _vi is string else _vi -%}
+                  {%- import 'zenos_cabinets.jinja' as CABS -%}
+                  {%- set _vi = CABS.cabinet_drawer_value(_hh_cab, 'AI_Cabinet_VolumeInfo', {}) | from_json() -%}
                   {{- _vi | tojson -}}
                 _hh_members_raw: >-
-                  {%- set _v = state_attr(_hh_cab, 'variables') | default({}, true) -%}
-                  {%- set _v = _v if _v is mapping else {} -%}
-                  {%- set _m = _v.get('members', {}) -%}
-                  {%- set _m = _m if _m is mapping else (_m | from_json if _m is string else {}) -%}
-                  {%- set _m = _m.get('value', _m) if _m is mapping else {} -%}
+                  {%- import 'zenos_cabinets.jinja' as CABS -%}
+                  {%- set _m = CABS.cabinet_drawer_value(_hh_cab, 'members', {}) | from_json() -%}
                   {{- _m | tojson -}}
                 _mem_vi_raw: >-
-                  {%- set _v = state_attr(member_entity, 'variables') | default({}, true) -%}
-                  {%- set _v = _v if _v is mapping else {} -%}
-                  {%- set _vi = _v.get('AI_Cabinet_VolumeInfo', _v) -%}
-                  {%- set _vi = _vi.get('value', _vi) if _vi is mapping else {} -%}
-                  {%- set _vi = _vi | from_json if _vi is string else _vi -%}
+                  {%- import 'zenos_cabinets.jinja' as CABS -%}
+                  {%- set _vi = CABS.cabinet_drawer_value(member_entity, 'AI_Cabinet_VolumeInfo', {}) | from_json() -%}
                   {{- _vi | tojson -}}
             - variables:
                 _hh_vi: "{{- _hh_vi_raw | from_json if _hh_vi_raw is string else (_hh_vi_raw if _hh_vi_raw is mapping else {}) -}}"
@@ -1003,18 +976,12 @@ script:
             - variables:
                 _list_key: "{{- 'ai_users' if member_type == 'ai_user' else 'users' -}}"
                 _hh_members_raw: >-
-                  {%- set _v = state_attr(_hh_cab, 'variables') | default({}, true) -%}
-                  {%- set _v = _v if _v is mapping else {} -%}
-                  {%- set _m = _v.get('members', {}) -%}
-                  {%- set _m = _m if _m is mapping else (_m | from_json if _m is string else {}) -%}
-                  {%- set _m = _m.get('value', _m) if _m is mapping else {} -%}
+                  {%- import 'zenos_cabinets.jinja' as CABS -%}
+                  {%- set _m = CABS.cabinet_drawer_value(_hh_cab, 'members', {}) | from_json() -%}
                   {{- _m | tojson -}}
                 _hh_vi_raw: >-
-                  {%- set _v = state_attr(_hh_cab, 'variables') | default({}, true) -%}
-                  {%- set _v = _v if _v is mapping else {} -%}
-                  {%- set _vi = _v.get('AI_Cabinet_VolumeInfo', _v) -%}
-                  {%- set _vi = _vi.get('value', _vi) if _vi is mapping else {} -%}
-                  {%- set _vi = _vi | from_json if _vi is string else _vi -%}
+                  {%- import 'zenos_cabinets.jinja' as CABS -%}
+                  {%- set _vi = CABS.cabinet_drawer_value(_hh_cab, 'AI_Cabinet_VolumeInfo', {}) | from_json() -%}
                   {{- _vi | tojson -}}
             - variables:
                 _updated_members: >-
@@ -1104,18 +1071,12 @@ script:
                   response_variable: response
             - variables:
                 _hh_vi_raw: >-
-                  {%- set _v = state_attr(_target_cab, 'variables') | default({}, true) -%}
-                  {%- set _v = _v if _v is mapping else {} -%}
-                  {%- set _vi = _v.get('AI_Cabinet_VolumeInfo', _v) -%}
-                  {%- set _vi = _vi.get('value', _vi) if _vi is mapping else {} -%}
-                  {%- set _vi = _vi | from_json if _vi is string else _vi -%}
+                  {%- import 'zenos_cabinets.jinja' as CABS -%}
+                  {%- set _vi = CABS.cabinet_drawer_value(_target_cab, 'AI_Cabinet_VolumeInfo', {}) | from_json() -%}
                   {{- _vi | tojson -}}
                 _mem_vi_raw: >-
-                  {%- set _v = state_attr(member_entity, 'variables') | default({}, true) -%}
-                  {%- set _v = _v if _v is mapping else {} -%}
-                  {%- set _vi = _v.get('AI_Cabinet_VolumeInfo', _v) -%}
-                  {%- set _vi = _vi.get('value', _vi) if _vi is mapping else {} -%}
-                  {%- set _vi = _vi | from_json if _vi is string else _vi -%}
+                  {%- import 'zenos_cabinets.jinja' as CABS -%}
+                  {%- set _vi = CABS.cabinet_drawer_value(member_entity, 'AI_Cabinet_VolumeInfo', {}) | from_json() -%}
                   {{- _vi | tojson -}}
             - variables:
                 _mem_guid: >-
@@ -1206,25 +1167,16 @@ script:
                   response_variable: response
             - variables:
                 _fam_members_raw: >-
-                  {%- set _v = state_attr(family_entity, 'variables') | default({}, true) -%}
-                  {%- set _v = _v if _v is mapping else {} -%}
-                  {%- set _m = _v.get('members', {}) -%}
-                  {%- set _m = _m if _m is mapping else (_m | from_json if _m is string else {}) -%}
-                  {%- set _m = _m.get('value', _m) if _m is mapping else {} -%}
+                  {%- import 'zenos_cabinets.jinja' as CABS -%}
+                  {%- set _m = CABS.cabinet_drawer_value(family_entity, 'members', {}) | from_json() -%}
                   {{- _m | tojson -}}
                 _mem_vi_raw: >-
-                  {%- set _v = state_attr(member_entity, 'variables') | default({}, true) -%}
-                  {%- set _v = _v if _v is mapping else {} -%}
-                  {%- set _vi = _v.get('AI_Cabinet_VolumeInfo', _v) -%}
-                  {%- set _vi = _vi.get('value', _vi) if _vi is mapping else {} -%}
-                  {%- set _vi = _vi | from_json if _vi is string else _vi -%}
+                  {%- import 'zenos_cabinets.jinja' as CABS -%}
+                  {%- set _vi = CABS.cabinet_drawer_value(member_entity, 'AI_Cabinet_VolumeInfo', {}) | from_json() -%}
                   {{- _vi | tojson -}}
                 _fam_vi_raw: >-
-                  {%- set _v = state_attr(family_entity, 'variables') | default({}, true) -%}
-                  {%- set _v = _v if _v is mapping else {} -%}
-                  {%- set _vi = _v.get('AI_Cabinet_VolumeInfo', _v) -%}
-                  {%- set _vi = _vi.get('value', _vi) if _vi is mapping else {} -%}
-                  {%- set _vi = _vi | from_json if _vi is string else _vi -%}
+                  {%- import 'zenos_cabinets.jinja' as CABS -%}
+                  {%- set _vi = CABS.cabinet_drawer_value(family_entity, 'AI_Cabinet_VolumeInfo', {}) | from_json() -%}
                   {{- _vi | tojson -}}
             - variables:
                 _mem_guid: >-
@@ -1403,25 +1355,16 @@ script:
                   response_variable: response
             - variables:
                 _fam_members_raw: >-
-                  {%- set _v = state_attr(family_entity, 'variables') | default({}, true) -%}
-                  {%- set _v = _v if _v is mapping else {} -%}
-                  {%- set _m = _v.get('members', {}) -%}
-                  {%- set _m = _m if _m is mapping else (_m | from_json if _m is string else {}) -%}
-                  {%- set _m = _m.get('value', _m) if _m is mapping else {} -%}
+                  {%- import 'zenos_cabinets.jinja' as CABS -%}
+                  {%- set _m = CABS.cabinet_drawer_value(family_entity, 'members', {}) | from_json() -%}
                   {{- _m | tojson -}}
                 _mem_vi_raw: >-
-                  {%- set _v = state_attr(member_entity, 'variables') | default({}, true) -%}
-                  {%- set _v = _v if _v is mapping else {} -%}
-                  {%- set _vi = _v.get('AI_Cabinet_VolumeInfo', _v) -%}
-                  {%- set _vi = _vi.get('value', _vi) if _vi is mapping else {} -%}
-                  {%- set _vi = _vi | from_json if _vi is string else _vi -%}
+                  {%- import 'zenos_cabinets.jinja' as CABS -%}
+                  {%- set _vi = CABS.cabinet_drawer_value(member_entity, 'AI_Cabinet_VolumeInfo', {}) | from_json() -%}
                   {{- _vi | tojson -}}
                 _fam_vi_raw: >-
-                  {%- set _v = state_attr(family_entity, 'variables') | default({}, true) -%}
-                  {%- set _v = _v if _v is mapping else {} -%}
-                  {%- set _vi = _v.get('AI_Cabinet_VolumeInfo', _v) -%}
-                  {%- set _vi = _vi.get('value', _vi) if _vi is mapping else {} -%}
-                  {%- set _vi = _vi | from_json if _vi is string else _vi -%}
+                  {%- import 'zenos_cabinets.jinja' as CABS -%}
+                  {%- set _vi = CABS.cabinet_drawer_value(family_entity, 'AI_Cabinet_VolumeInfo', {}) | from_json() -%}
                   {{- _vi | tojson -}}
             - variables:
                 _fam_guid: >-
@@ -1464,11 +1407,8 @@ script:
                   {%- set _vi = _vi if _vi is mapping else {} -%}
                   {{- _vi.get('default_family_guid', '') == _fam_guid -}}
                 _fam_vi_raw2: >-
-                  {%- set _v = state_attr(family_entity, 'variables') | default({}, true) -%}
-                  {%- set _v = _v if _v is mapping else {} -%}
-                  {%- set _vi = _v.get('AI_Cabinet_VolumeInfo', _v) -%}
-                  {%- set _vi = _vi.get('value', _vi) if _vi is mapping else {} -%}
-                  {%- set _vi = _vi | from_json if _vi is string else _vi -%}
+                  {%- import 'zenos_cabinets.jinja' as CABS -%}
+                  {%- set _vi = CABS.cabinet_drawer_value(family_entity, 'AI_Cabinet_VolumeInfo', {}) | from_json() -%}
                   {{- _vi | tojson -}}
                 _principal_warning: >-
                   {%- set _vi = _fam_vi_raw2 | from_json if _fam_vi_raw2 is string else _fam_vi_raw2 -%}
@@ -1583,18 +1523,12 @@ script:
                   response_variable: response
             - variables:
                 _a_vi_raw: >-
-                  {%- set _v = state_attr(member_entity, 'variables') | default({}, true) -%}
-                  {%- set _v = _v if _v is mapping else {} -%}
-                  {%- set _vi = _v.get('AI_Cabinet_VolumeInfo', _v) -%}
-                  {%- set _vi = _vi.get('value', _vi) if _vi is mapping else {} -%}
-                  {%- set _vi = _vi | from_json if _vi is string else _vi -%}
+                  {%- import 'zenos_cabinets.jinja' as CABS -%}
+                  {%- set _vi = CABS.cabinet_drawer_value(member_entity, 'AI_Cabinet_VolumeInfo', {}) | from_json() -%}
                   {{- _vi | tojson -}}
                 _b_vi_raw: >-
-                  {%- set _v = state_attr(ai_entity, 'variables') | default({}, true) -%}
-                  {%- set _v = _v if _v is mapping else {} -%}
-                  {%- set _vi = _v.get('AI_Cabinet_VolumeInfo', _v) -%}
-                  {%- set _vi = _vi.get('value', _vi) if _vi is mapping else {} -%}
-                  {%- set _vi = _vi | from_json if _vi is string else _vi -%}
+                  {%- import 'zenos_cabinets.jinja' as CABS -%}
+                  {%- set _vi = CABS.cabinet_drawer_value(ai_entity, 'AI_Cabinet_VolumeInfo', {}) | from_json() -%}
                   {{- _vi | tojson -}}
             - variables:
                 _a_guid: >-
@@ -1708,18 +1642,12 @@ script:
                   response_variable: response
             - variables:
                 _a_vi_raw: >-
-                  {%- set _v = state_attr(member_entity, 'variables') | default({}, true) -%}
-                  {%- set _v = _v if _v is mapping else {} -%}
-                  {%- set _vi = _v.get('AI_Cabinet_VolumeInfo', _v) -%}
-                  {%- set _vi = _vi.get('value', _vi) if _vi is mapping else {} -%}
-                  {%- set _vi = _vi | from_json if _vi is string else _vi -%}
+                  {%- import 'zenos_cabinets.jinja' as CABS -%}
+                  {%- set _vi = CABS.cabinet_drawer_value(member_entity, 'AI_Cabinet_VolumeInfo', {}) | from_json() -%}
                   {{- _vi | tojson -}}
                 _b_vi_raw: >-
-                  {%- set _v = state_attr(ai_entity, 'variables') | default({}, true) -%}
-                  {%- set _v = _v if _v is mapping else {} -%}
-                  {%- set _vi = _v.get('AI_Cabinet_VolumeInfo', _v) -%}
-                  {%- set _vi = _vi.get('value', _vi) if _vi is mapping else {} -%}
-                  {%- set _vi = _vi | from_json if _vi is string else _vi -%}
+                  {%- import 'zenos_cabinets.jinja' as CABS -%}
+                  {%- set _vi = CABS.cabinet_drawer_value(ai_entity, 'AI_Cabinet_VolumeInfo', {}) | from_json() -%}
                   {{- _vi | tojson -}}
             - variables:
                 _a_name: >-
@@ -1807,18 +1735,12 @@ script:
                   response_variable: response
             - variables:
                 _mem_vi_raw: >-
-                  {%- set _v = state_attr(member_entity, 'variables') | default({}, true) -%}
-                  {%- set _v = _v if _v is mapping else {} -%}
-                  {%- set _vi = _v.get('AI_Cabinet_VolumeInfo', _v) -%}
-                  {%- set _vi = _vi.get('value', _vi) if _vi is mapping else {} -%}
-                  {%- set _vi = _vi | from_json if _vi is string else _vi -%}
+                  {%- import 'zenos_cabinets.jinja' as CABS -%}
+                  {%- set _vi = CABS.cabinet_drawer_value(member_entity, 'AI_Cabinet_VolumeInfo', {}) | from_json() -%}
                   {{- _vi | tojson -}}
                 _fam_vi_raw: >-
-                  {%- set _v = state_attr(family_entity, 'variables') | default({}, true) -%}
-                  {%- set _v = _v if _v is mapping else {} -%}
-                  {%- set _vi = _v.get('AI_Cabinet_VolumeInfo', _v) -%}
-                  {%- set _vi = _vi.get('value', _vi) if _vi is mapping else {} -%}
-                  {%- set _vi = _vi | from_json if _vi is string else _vi -%}
+                  {%- import 'zenos_cabinets.jinja' as CABS -%}
+                  {%- set _vi = CABS.cabinet_drawer_value(family_entity, 'AI_Cabinet_VolumeInfo', {}) | from_json() -%}
                   {{- _vi | tojson -}}
             - variables:
                 _fam_guid: >-
@@ -1872,18 +1794,12 @@ script:
                 _hh_default: "{{- _hh_target -}}"
             - variables:
                 _root_vi_raw: >-
-                  {%- set _v = state_attr(_root_entity, 'variables') | default({}, true) -%}
-                  {%- set _v = _v if _v is mapping else {} -%}
-                  {%- set _vi = _v.get('AI_Cabinet_VolumeInfo', _v) -%}
-                  {%- set _vi = _vi.get('value', _vi) if _vi is mapping else {} -%}
-                  {%- set _vi = _vi | from_json if _vi is string else _vi -%}
+                  {%- import 'zenos_cabinets.jinja' as CABS -%}
+                  {%- set _vi = CABS.cabinet_drawer_value(_root_entity, 'AI_Cabinet_VolumeInfo', {}) | from_json() -%}
                   {{- _vi | tojson -}}
                 _root_members_raw: >-
-                  {%- set _v = state_attr(_root_entity, 'variables') | default({}, true) -%}
-                  {%- set _v = _v if _v is mapping else {} -%}
-                  {%- set _m = _v.get('members', {}) -%}
-                  {%- set _m = _m if _m is mapping else (_m | from_json if _m is string else {}) -%}
-                  {%- set _m = _m.get('value', _m) if _m is mapping else {} -%}
+                  {%- import 'zenos_cabinets.jinja' as CABS -%}
+                  {%- set _m = CABS.cabinet_drawer_value(_root_entity, 'members', {}) | from_json() -%}
                   {{- _m | tojson -}}
                 _root_profile_raw: >-
                   {%- set _v = state_attr(_root_entity, 'variables') | default({}, true) -%}
@@ -2018,18 +1934,12 @@ script:
                         _target_eid: "{{- _root_entity -}}"
                     - variables:
                         _hh_vi_raw: >-
-                          {%- set _v = state_attr(_lookup_root, 'variables') | default({}, true) -%}
-                          {%- set _v = _v if _v is mapping else {} -%}
-                          {%- set _vi = _v.get('AI_Cabinet_VolumeInfo', _v) -%}
-                          {%- set _vi = _vi.get('value', _vi) if _vi is mapping else {} -%}
-                          {%- set _vi = _vi | from_json if _vi is string else _vi -%}
+                          {%- import 'zenos_cabinets.jinja' as CABS -%}
+                          {%- set _vi = CABS.cabinet_drawer_value(_lookup_root, 'AI_Cabinet_VolumeInfo', {}) | from_json() -%}
                           {{- _vi | tojson -}}
                         _hh_m_raw: >-
-                          {%- set _v = state_attr(_lookup_root, 'variables') | default({}, true) -%}
-                          {%- set _v = _v if _v is mapping else {} -%}
-                          {%- set _m = _v.get('members', {}) -%}
-                          {%- set _m = _m if _m is mapping else (_m | from_json if _m is string else {}) -%}
-                          {%- set _m = _m.get('value', _m) if _m is mapping else {} -%}
+                          {%- import 'zenos_cabinets.jinja' as CABS -%}
+                          {%- set _m = CABS.cabinet_drawer_value(_lookup_root, 'members', {}) | from_json() -%}
                           {{- _m | tojson -}}
                     - variables:
                         _memberships: >-
@@ -2127,11 +2037,8 @@ script:
                   response_variable: response
             - variables:
                 _container_m_raw: >-
-                  {%- set _v = state_attr(family_entity, 'variables') | default({}, true) -%}
-                  {%- set _v = _v if _v is mapping else {} -%}
-                  {%- set _m = _v.get('members', {}) -%}
-                  {%- set _m = _m if _m is mapping else (_m | from_json if _m is string else {}) -%}
-                  {%- set _m = _m.get('value', _m) if _m is mapping else {} -%}
+                  {%- import 'zenos_cabinets.jinja' as CABS -%}
+                  {%- set _m = CABS.cabinet_drawer_value(family_entity, 'members', {}) | from_json() -%}
                   {{- _m | tojson -}}
             - variables:
                 _check: >-

--- a/packages/zenos_ai/dojotools/dojotools_identity.yaml
+++ b/packages/zenos_ai/dojotools/dojotools_identity.yaml
@@ -404,6 +404,7 @@ script:
                 _roster_raw: >-
                   {% import 'zenos_ai/zen_os_1.jinja' as zen %}
                   {{- zen.identity_roster() -}}
+                # @todo - surely no need to check what is in _roster_raw? - we control its contents - it's a JSON-Stringified dict
                 _roster: >-
                   {%- set raw = _roster_raw | trim -%}
                   {%- if raw.startswith('{') -%}
@@ -481,6 +482,9 @@ script:
                       'members': {'users': _m.get('users', []), 'ai_users': _m.get('ai_users', []), 'families': _ns.fams}
                     } | tojson
                   }}
+                # ------------------------------------------------------------------------------------
+                # @note - _manifest: a dict with two keys each having a JSON-STRINGIFIED DICT ()
+                # ------------------------------------------------------------------------------------
                 _manifest: >-
                   {{
                     {

--- a/packages/zenos_ai/dojotools/dojotools_identity.yaml
+++ b/packages/zenos_ai/dojotools/dojotools_identity.yaml
@@ -551,7 +551,8 @@ script:
                   {%- if _existing != '' -%}
                     {{- _existing -}}
                   {%- else -%}
-                    {{- '%04x%04x-%04x-%04x-%04x-%04x%04x%04x' | format( range(0, 65536) | random, range(0, 65536) | random, range(0, 65536) | random, range(0, 65536) | random, range(0, 65536) | random, range(0, 65536) | random, range(0, 65536) | random, range(0, 65536) | random) -}}
+                    {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
+                    {{- CABS.cabinet_guid_new() -}}
                   {%- endif -%}
                 _fam_guid_is_new: >-
                   {%- set _vi = _fam_vi_raw | from_json if _fam_vi_raw is string else _fam_vi_raw -%}
@@ -766,7 +767,8 @@ script:
                   {%- set _vi = _vi if _vi is mapping else {} -%}
                   {%- set _existing = _vi.get('id', _vi.get('guid', '')) | string | trim -%}
                   {%- if _existing != '' -%}{{- _existing -}}{%- else -%}
-                  {{- '%04x%04x-%04x-%04x-%04x-%04x%04x%04x' | format( range(0, 65536) | random, range(0, 65536) | random, range(0, 65536) | random, range(0, 65536) | random, range(0, 65536) | random, range(0, 65536) | random, range(0, 65536) | random, range(0, 65536) | random) -}}
+                    {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
+                    {{- CABS.cabinet_guid_new() -}}
                   {%- endif -%}
                 _mem_guid_is_new: >-
                   {%- set _vi = _mem_vi_raw | from_json if _mem_vi_raw is string else _mem_vi_raw -%}
@@ -1179,7 +1181,8 @@ script:
                   {%- set _vi = _vi if _vi is mapping else {} -%}
                   {%- set _existing = _vi.get('id', _vi.get('guid', '')) | string | trim -%}
                   {%- if _existing != '' -%}{{- _existing -}}{%- else -%}
-                  {{- '%04x%04x-%04x-%04x-%04x-%04x%04x%04x' | format( range(0, 65536) | random, range(0, 65536) | random, range(0, 65536) | random, range(0, 65536) | random, range(0, 65536) | random, range(0, 65536) | random, range(0, 65536) | random, range(0, 65536) | random) -}}
+                    {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
+                    {{- CABS.cabinet_guid_new() -}}
                   {%- endif -%}
                 # @todo - need to modify CABS.cabinet_drawer_value() so it can take a list of keys and return the first one that exists
                 _mem_name: >-

--- a/packages/zenos_ai/dojotools/dojotools_index.yaml
+++ b/packages/zenos_ai/dojotools/dojotools_index.yaml
@@ -1171,11 +1171,8 @@ script:
       then:
       - variables:
           _cid_todo: >-
-            {%- set _a = range(0,65536)|random -%}{%- set _b = range(0,65536)|random -%}
-            {%- set _c = range(0,65536)|random -%}{%- set _d = range(0,65536)|random -%}
-            {%- set _e = range(0,65536)|random -%}{%- set _f = range(0,65536)|random -%}
-            {%- set _g = range(0,65536)|random -%}{%- set _h = range(0,65536)|random -%}
-            {{ '%04x%04x-%04x-%04x-%04x-%04x%04x%04x' | format(_a,_b,_c,_d,_e,_f,_g,_h) }}
+            {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
+            {{- CABS.cabinet_guid_new() -}}
       - event: zen_event
         event_data:
           event:
@@ -1207,11 +1204,8 @@ script:
       then:
       - variables:
           _cid_cal: >-
-            {%- set _a = range(0,65536)|random -%}{%- set _b = range(0,65536)|random -%}
-            {%- set _c = range(0,65536)|random -%}{%- set _d = range(0,65536)|random -%}
-            {%- set _e = range(0,65536)|random -%}{%- set _f = range(0,65536)|random -%}
-            {%- set _g = range(0,65536)|random -%}{%- set _h = range(0,65536)|random -%}
-            {{ '%04x%04x-%04x-%04x-%04x-%04x%04x%04x' | format(_a,_b,_c,_d,_e,_f,_g,_h) }}
+            {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
+            {{- CABS.cabinet_guid_new() -}}
       - event: zen_event
         event_data:
           event:

--- a/packages/zenos_ai/dojotools/dojotools_manifest.yaml
+++ b/packages/zenos_ai/dojotools/dojotools_manifest.yaml
@@ -302,18 +302,8 @@ script:
     sequence:
     - variables:
         new_guid: >
-          {{- '%04x%04x-%04x-%04x-%04x-%04x%04x%04x'
-            | format(
-                range(0, 65536) | random,
-                range(0, 65536) | random,
-                range(0, 65536) | random,
-                range(0, 65536) | random,
-                range(0, 65536) | random,
-                range(0, 65536) | random,
-                range(0, 65536) | random,
-                range(0, 65536) | random
-              ) 
-          -}}
+          {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
+          {{- CABS.cabinet_guid_new() -}}
     - alias: Stamp AI_Cabinet_VolumeInfo
       event: set_variable_zenos_default_family_cabinet
       event_data:

--- a/packages/zenos_ai/dojotools/dojotools_profile.yaml
+++ b/packages/zenos_ai/dojotools/dojotools_profile.yaml
@@ -683,12 +683,8 @@ script:
                     {%- if _existing_guid != '' -%}
                       {{ _existing_guid }}
                     {%- else -%}
-                      {{ '%04x%04x-%04x-%04x-%04x-%04x%04x%04x' | format(
-                        range(0, 65536) | random, range(0, 65536) | random,
-                        range(0, 65536) | random, range(0, 65536) | random,
-                        range(0, 65536) | random, range(0, 65536) | random,
-                        range(0, 65536) | random, range(0, 65536) | random
-                      ) }}
+                      {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
+                      {{- CABS.cabinet_guid_new() -}}
                     {%- endif -%}
 
               # Step B — assemble three-layer essence (core / jacket / companion).

--- a/packages/zenos_ai/dojotools/dojotools_profile.yaml
+++ b/packages/zenos_ai/dojotools/dojotools_profile.yaml
@@ -649,13 +649,16 @@ script:
               # Step A.5 — resolve principal chain (stamp once, preserve always)
               - variables:
                   _hh_cab: "{{ states('sensor.zen_default_household_cabinet_resolved') }}"
-                  _hh_vars: >-
-                    {{ state_attr(_hh_cab, 'variables') | default({}, true) if _hh_cab != '' else {} }}
+                  #_hh_vars: >-
+                  #  {{ state_attr(_hh_cab, 'variables') | default({}, true) if _hh_cab != '' else {} }}
+                  #_hh_vi: >-
+                  #  {%- set _vi = _hh_vars.get('AI_Cabinet_VolumeInfo', {}) if _hh_vars is mapping else {} -%}
+                  #  {%- set _v1 = _vi.get('value', _vi) if _vi is mapping else {} -%}
+                  #  {%- set _v2 = _v1 if _v1 is mapping else (_v1 | from_json if _v1 is string else {}) -%}
+                  #  {{ _v2 if _v2 is mapping else (_v2 | from_json if _v2 is string else {}) }}
                   _hh_vi: >-
-                    {%- set _vi = _hh_vars.get('AI_Cabinet_VolumeInfo', {}) if _hh_vars is mapping else {} -%}
-                    {%- set _v1 = _vi.get('value', _vi) if _vi is mapping else {} -%}
-                    {%- set _v2 = _v1 if _v1 is mapping else (_v1 | from_json if _v1 is string else {}) -%}
-                    {{ _v2 if _v2 is mapping else (_v2 | from_json if _v2 is string else {}) }}
+                    {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
+                    {%- set essence = CABS.cabinet_drawer_value(_hh_cab, 'AI_Cabinet_VolumeInfo') | from_json() -%}
                   _household_id: "{{ _hh_vi.get('id', '') if _hh_vi is mapping else '' }}"
                   _puser_entity: >-
                     {{ _in_puser if _in_puser.startswith('person.') else

--- a/packages/zenos_ai/dojotools/dojotools_summarizers.yaml
+++ b/packages/zenos_ai/dojotools/dojotools_summarizers.yaml
@@ -726,15 +726,8 @@ script:
         then:
           - variables:
               _inspect_cid: >-
-                {%- set _a = range(0, 65536) | random -%}
-                {%- set _b = range(0, 65536) | random -%}
-                {%- set _c = range(0, 65536) | random -%}
-                {%- set _d = range(0, 65536) | random -%}
-                {%- set _e = range(0, 65536) | random -%}
-                {%- set _f = range(0, 65536) | random -%}
-                {%- set _g = range(0, 65536) | random -%}
-                {%- set _h = range(0, 65536) | random -%}
-                {{ '%04x%04x-%04x-%04x-%04x-%04x%04x%04x' | format(_a,_b,_c,_d,_e,_f,_g,_h) }}
+                {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
+                {{- CABS.cabinet_guid_new() -}}
           - event: zen_event
             event_data:
               event:
@@ -967,15 +960,8 @@ script:
         then:
           - variables:
               _urgency_correlation_id: >-
-                {%- set _a = range(0, 65536) | random -%}
-                {%- set _b = range(0, 65536) | random -%}
-                {%- set _c = range(0, 65536) | random -%}
-                {%- set _d = range(0, 65536) | random -%}
-                {%- set _e = range(0, 65536) | random -%}
-                {%- set _f = range(0, 65536) | random -%}
-                {%- set _g = range(0, 65536) | random -%}
-                {%- set _h = range(0, 65536) | random -%}
-                {{ '%04x%04x-%04x-%04x-%04x-%04x%04x%04x' | format(_a,_b,_c,_d,_e,_f,_g,_h) }}
+                {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
+                {{- CABS.cabinet_guid_new() -}}
           - event: zen_event
             event_data:
               event:

--- a/packages/zenos_ai/flynn.yaml
+++ b/packages/zenos_ai/flynn.yaml
@@ -74,13 +74,13 @@ template:
         unique_id: zen_select_persona
         icon: mdi:account-star
         state: "{{ states('input_text.zenos_persona_name') }}"
+        # @todo - no need to coerce sensor.zen_default_ai_user_cabinet_resolved to a list and then check the length at the end - there is onle one cab(s)!
         options: >-
+          {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
           {%- set cabs = [states('sensor.zen_default_ai_user_cabinet_resolved')] -%}
           {%- set names = namespace(list=[]) -%}
           {%- for cab in cabs -%}
-            {%- set vars = state_attr(cab, 'variables') | default({}, true) -%}
-            {%- set essence_raw = vars.get('zenai_essence', {}) if vars is mapping else {} -%}
-            {%- set essence = essence_raw.get('value', essence_raw) if essence_raw is mapping else {} -%}
+            {%- set essence = CABS.cabinet_drawer_value(cab, 'zenai_essence') | from_json() -%}
             {%- set name = essence.get('identity', {}).get('name', '') | trim -%}
             {%- if name not in ['', 'your AI', 'unknown'] -%}
               {%- set names.list = names.list + [name] -%}
@@ -245,17 +245,25 @@ automation:
       - variables:
           was_green: "{{ is_state('binary_sensor.flynn_system_ready', 'on') }}"
           _oobe_ai_cab: "{{ states('sensor.zen_default_ai_user_cabinet_resolved') }}"
+          #_oobe_cab_vars: >-
+          #  {{ state_attr(_oobe_ai_cab, 'variables') | default({}, true)
+          #     if _oobe_ai_cab != '' else {} }}
           _oobe_cab_vars: >-
-            {{ state_attr(_oobe_ai_cab, 'variables') | default({}, true)
-               if _oobe_ai_cab != '' else {} }}
+            {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
+            {{- CABS.cabinet_variables(_oobe_ai_cab) | from_json() -}}
           _oobe_complete: "{{ '_oobe_complete' in _oobe_cab_vars }}"
-          _oobe_essence_raw: "{{ _oobe_cab_vars.get('zenai_essence', {}) }}"
+          #_oobe_essence_raw: "{{ _oobe_cab_vars.get('zenai_essence', {}) }}"
+          #_oobe_essence_val: >-
+          #  {{ _oobe_essence_raw.get('value', _oobe_essence_raw)
+          #     if _oobe_essence_raw is mapping else {} }}
           _oobe_essence_val: >-
-            {{ _oobe_essence_raw.get('value', _oobe_essence_raw)
-               if _oobe_essence_raw is mapping else {} }}
+            {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
+            {{- CABS.cabinet_drawer_value(_oobe_ai_cab, 'zenai_essence') | from_json() -}}
+          #_oobe_name: >-
+          #  {{ (_oobe_essence_val.get('identity', {}).get('name', '') | trim)
+          #     if _oobe_essence_val is mapping else '' }}
           _oobe_name: >-
-            {{ (_oobe_essence_val.get('identity', {}).get('name', '') | trim)
-               if _oobe_essence_val is mapping else '' }}
+            {{- (_oobe_essence_val.get('identity', {}).get('name', '') | trim) -}}
           _oobe_pending: "{{ not _oobe_complete and (_oobe_name in ['', 'your AI', 'unknown']) }}"
       # Early exit: skip when all gates green (or monastery warn) AND oobe done.
       # warn = degraded-but-functional; no bootstrap needed, agent is usable.

--- a/packages/zenos_ai/maint/repair_user_cab_essence.yaml
+++ b/packages/zenos_ai/maint/repair_user_cab_essence.yaml
@@ -142,11 +142,9 @@ script:
 
     - variables:
         _guid: >-
-          {%- set _v = _vi_info | from_json if _vi_info is string else (_vi_info if _vi_info is mapping else {}) -%}
-          {{ _v.get('guid', '') }}
+          {{ _vi_info.get('guid', '') }}
         _vi_friendly_name: >-
-          {%- set _v = _vi_info | from_json if _vi_info is string else (_vi_info if _vi_info is mapping else {}) -%}
-          {{ _v.get('friendly_name', '') }}
+          {{ _vi_info.get('friendly_name', '') }}
 
     # Guard: GUID must be present before writing anything
     - if: "{{ _guid == '' }}"
@@ -166,10 +164,14 @@ script:
     # FG-38 safe: two-round normalization on profile
     - variables:
         _profile_info: >-
+          {#-
           {%- set _p = _cab_vars.get('_user_profile', {}) -%}
           {%- set _p = _p if _p is mapping else (_p | from_json if _p is string else {}) -%}
           {%- set _p = _p.get('value', _p) if _p is mapping else {} -%}
           {%- set _p = _p if _p is mapping else (_p | from_json if _p is string else {}) -%}
+          -#}
+          {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
+          {%- set _p = CABS.cabinet_drawer_value(_target_cab, '_user_profile') | from_json() -%}
           {{ {
             'name': _p.get('name', '') | trim,
             'person_entity': _p.get('person_entity', '') | trim
@@ -308,15 +310,21 @@ script:
     # ── Verify ────────────────────────────────────────────────────────────────
     - delay: "00:00:01"
     - variables:
-        _post_vars_raw: "{{ state_attr(_target_cab, 'variables') | default({}, true) }}"
-        _post_vars: "{{ _post_vars_raw if _post_vars_raw is mapping else {} }}"
+        #_post_vars_raw: "{{ state_attr(_target_cab, 'variables') | default({}, true) }}"
+        #_post_vars: "{{ _post_vars_raw if _post_vars_raw is mapping else {} }}"
+        #_post_verify: >-
+        #  {%- set _raw = _post_vars.get('zenai_essence', {}) -%}
+        #  {%- set _e = _raw if _raw is mapping else (_raw | from_json if _raw is string else {}) -%}
+        #  {%- set _e = _e.get('value', _e) if _e is mapping else {} -%}
+        #  {%- set _e = _e if _e is mapping else (_e | from_json if _e is string else {}) -%}
+        #  {%- set _core = _e.get('core', {}) if _e is mapping else {} -%}
+        #  {{ (_core.get('id', '') | trim) if _core is mapping else '' }}
+        _post_value: >
+          {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
+          {{- CABS.cabinet_drawer_value(_target_cab, 'zenai_essence') | from_json() -}}
         _post_verify: >-
-          {%- set _raw = _post_vars.get('zenai_essence', {}) -%}
-          {%- set _e = _raw if _raw is mapping else (_raw | from_json if _raw is string else {}) -%}
-          {%- set _e = _e.get('value', _e) if _e is mapping else {} -%}
-          {%- set _e = _e if _e is mapping else (_e | from_json if _e is string else {}) -%}
-          {%- set _core = _e.get('core', {}) if _e is mapping else {} -%}
-          {{ (_core.get('id', '') | trim) if _core is mapping else '' }}
+          {%- set _core = _post_value.get('core', {}) -%}
+          {{- _core.get('id', '') | trim -}}
 
     - variables:
         _verify_ok: "{{ _post_verify == _guid }}"

--- a/packages/zenos_ai/maint/repair_user_cab_essence.yaml
+++ b/packages/zenos_ai/maint/repair_user_cab_essence.yaml
@@ -116,17 +116,25 @@ script:
 
     # ── Read all cabinet variables once ──────────────────────────────────────
     - variables:
-        _cab_vars_raw: "{{ state_attr(_target_cab, 'variables') | default({}, true) }}"
-        _cab_vars: "{{ _cab_vars_raw if _cab_vars_raw is mapping else {} }}"
+        #_cab_vars_raw: "{{ state_attr(_target_cab, 'variables') | default({}, true) }}"
+        #_cab_vars: "{{ _cab_vars_raw if _cab_vars_raw is mapping else {} }}"
+        _cab_vars: >
+          {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
+          {{- CABS.cabinet_variables(_target_cab) | from_json() -}}
 
     # ── Read VolumeInfo → GUID + friendly_name ────────────────────────────────
     # FG-38 safe: two-round normalization
     - variables:
         _vi_info: >-
+          {#-
           {%- set _e = _cab_vars.get('AI_Cabinet_VolumeInfo', {}) -%}
           {%- set _e = _e if _e is mapping else (_e | from_json if _e is string else {}) -%}
           {%- set _vi = _e.get('value', _e) -%}
           {%- set _vi = _vi if _vi is mapping else (_vi | from_json if _vi is string else {}) -%}
+          -#}
+          {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
+          {%- set _vi = CABS.cabinet_drawer_value(_target_cab, 'AI_Cabinet_VolumeInfo') | from_json() -%}
+          
           {{ {
             'guid': _vi.get('id', '') | trim,
             'friendly_name': _vi.get('friendly_name', _vi.get('name', '')) | trim

--- a/packages/zenos_ai/sensors/zenos_cabinet_health.yaml
+++ b/packages/zenos_ai/sensors/zenos_cabinet_health.yaml
@@ -232,14 +232,15 @@ template:
 
           #####################################################################
           # SCROLL COUNT — drawers with ro: true across all online_mounted cabs
+          # @todo - this code is skipping the drawer.value when trying to read drawer.value.meta
           #####################################################################
           scroll_count: >-
+            {%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
             {%- set all_cabs = label_entities('Zen Cabinet' | slugify) | list -%}
             {%- set ns = namespace(n=0) -%}
             {%- for eid in all_cabs -%}
               {%- if states(eid) == 'online_mounted' -%}
-                {%- set vars = state_attr(eid, 'variables') | default({}, true) -%}
-                {%- set vars = vars if vars is mapping else {} -%}
+                {%- set vars = CABS.cabinet_variables(eid) | from_json() -%}
                 {%- for key, drawer in vars.items() if key != '_label_index' -%}
                   {%- set entry = drawer if drawer is mapping else {} -%}
                   {%- set mt = entry.get('meta', {}) -%}


### PR DESCRIPTION
Creates Cabinet macros

Refactors a limited subset to the existing code-base

Primarily - CABS.cabinet_drawer_value()

```
{%- import 'zenos_ai/zenos_cabinets.jinja' as CABS -%}
{%- set _vi = CABS.cabinet_drawer_value(family_entity, 'AI_Cabinet_VolumeInfo', {}) | from_json() -%}